### PR TITLE
feat: GitHub clone-and-traverse agent + skills autocomplete fix

### DIFF
--- a/agents/react_tools.py
+++ b/agents/react_tools.py
@@ -10,12 +10,11 @@ from typing import Any, Dict, Optional, Union
 from langchain_core.tools import StructuredTool
 from pydantic import AliasChoices, BaseModel, EmailStr, Field, HttpUrl
 
-from prompts.github import get_chain as get_github_chain
 from prompts.website import get_answer as get_website_answer
 from prompts.website import get_chain as get_website_chain
 from prompts.youtube import get_answer as get_youtube_answer
 from prompts.youtube import get_chain as get_youtube_chain
-from tools.github_crawler.convertor import convert_github_repo_to_markdown
+from tools.github_crawler.repo_agent import run_github_repo_agent
 from tools.google_search.seach_agent import web_search_pipeline
 from tools.website_context import markdown_fetcher
 from tools.gmail.fetch_latest_mails import get_latest_emails
@@ -211,7 +210,6 @@ class PyjiitAttendanceInput(BaseModel):
     )
 
 
-github_chain = get_github_chain()
 website_chain = get_website_chain()
 youtube_chain = get_youtube_chain()
 
@@ -219,17 +217,11 @@ youtube_chain = get_youtube_chain()
 async def _github_tool(
     url: HttpUrl, question: str, chat_history: Optional[list[dict[str, Any]]] = None
 ) -> str:
-    repo_data = await convert_github_repo_to_markdown(url)
-    history = _format_chat_history(chat_history)
-    payload = {
-        "question": question,
-        "text": repo_data.content,
-        "tree": repo_data.tree,
-        "summary": repo_data.summary,
-        "chat_history": history,
-    }
-    response = await asyncio.to_thread(github_chain.invoke, payload)
-    return _ensure_text(response)
+    return await run_github_repo_agent(
+        url=str(url),
+        question=question,
+        chat_history=chat_history,
+    )
 
 
 async def _websearch_tool(query: str, max_results: int = 5) -> str:

--- a/extension/entrypoints/sidepanel/AgentExecutor.tsx
+++ b/extension/entrypoints/sidepanel/AgentExecutor.tsx
@@ -778,13 +778,16 @@ export function AgentExecutor({ wsConnected }: AgentExecutorProps) {
 			}
 
 			if (!searchStr) {
-				// Show all if empty
-				setSlashSuggestions(availableSkills.map(s => `/skill-run ${s.name} `));
+				// Show all if empty — use id in the command so single-word parsing works
+				setSlashSuggestions(availableSkills.map(s => `/skill-run ${s.id} `));
 			} else {
-				// Filter by name
+				// Filter by name or id, but put id in the command string
 				const matches = availableSkills
-					.filter(s => s.name.toLowerCase().startsWith(searchStr))
-					.map(s => `/skill-run ${s.name} `);
+					.filter(s =>
+						s.name.toLowerCase().startsWith(searchStr) ||
+						s.id.toLowerCase().startsWith(searchStr)
+					)
+					.map(s => `/skill-run ${s.id} `);
 				setSlashSuggestions(matches);
 			}
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1,9 +1,7 @@
 from pydantic import HttpUrl
 
 from core import get_logger
-from core.llm import _model
-from prompts.github import get_chain
-from tools.github_crawler import convert_github_repo_to_markdown
+from tools.github_crawler.repo_agent import run_github_repo_agent
 
 logger = get_logger(__name__)
 
@@ -16,93 +14,43 @@ class GitHubService:
         chat_history: list[dict] = [],
         attached_file_path: str | None = None,
     ) -> str:
-        """Generate answer using GitHub repository information and prompt"""
-        # --- Step 1: Ingest the repository ---
-        try:
-            content_obj = await convert_github_repo_to_markdown(url)
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(f"Error ingesting GitHub repo ({url}): {error_msg}")
-
-            if "PathKind" in error_msg:
-                return (
-                    "The provided URL doesn't point to a valid GitHub repository root. "
-                    "Please navigate to the main repository page (e.g. `github.com/owner/repo`) and try again."
-                )
-            if "clone" in error_msg.lower() or "404" in error_msg:
-                return (
-                    "Could not access the GitHub repository. "
-                    "Make sure the URL is correct and the repository is public."
-                )
-            return f"Failed to fetch the GitHub repository: {error_msg}"
-
+        """Clone the repository and use a ReAct agent to answer the question."""
         if attached_file_path:
             logger.info("Attached file found: %s. Using google-genai SDK directly.", attached_file_path)
             try:
                 from google import genai
+                from core.llm import _model
                 import os
-                
+
                 api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
                 client = genai.Client(api_key=api_key)
                 uploaded_file = client.files.upload(file=attached_file_path)
-                
+
                 contents = [uploaded_file]
-                
-                if content_obj:
-                    # keep it concise if there is a lot of text, although 2.5-pro has 2M tokens
-                    contents.append(f"GitHub Repo Summary:\n{content_obj.summary}")
-                    contents.append(f"Repository Tree:\n{content_obj.tree}")
-                    # truncate text to avoid payload limits if too big, though Gemini pro handles up to 2M limits
-                    text_context = content_obj.content[:500000] if len(content_obj.content) > 500000 else content_obj.content
-                    contents.append(f"Repository Content:\n{text_context}")
-                
                 if chat_history:
-                    chat_history_str = ""
-                    for entry in chat_history:
-                        if isinstance(entry, dict):
-                            role = entry.get("role", "")
-                            content = entry.get("content", "")
-                            chat_history_str += f"{role}: {content}\n"
-                        else:
-                            chat_history_str += f"{entry}\n"
-                    contents.append(f"Chat History:\n{chat_history_str}")
-                    
+                    history_str = "\n".join(
+                        f"{e.get('role', '')}: {e.get('content', '')}"
+                        for e in chat_history
+                        if isinstance(e, dict)
+                    )
+                    contents.append(f"Chat History:\n{history_str}")
                 contents.append(question)
-                
+
                 response = client.models.generate_content(
                     model=_model.model_name,
-                    contents=contents
+                    contents=contents,
                 )
                 return response.text
             except Exception as e:
                 logger.error("Failed to process attached file with google-genai: %s", e)
                 return f"I couldn't process the attached file due to an error: {str(e)}"
-                
-        # --- Step 2: Generate answer with LLM ---
+
         try:
-            chain = get_chain()
-            response = chain.invoke(
-                {
-                    "summary": content_obj.summary,
-                    "tree": content_obj.tree,
-                    "text": content_obj.content,
-                    "question": question,
-                    "chat_history": chat_history if chat_history else "",
-                }
+            return await run_github_repo_agent(
+                url=str(url),
+                question=question,
+                chat_history=chat_history if chat_history else None,
             )
-
-            if isinstance(response, str):
-                return response
-
-            return response.content
-
         except Exception as e:
-            error_msg = str(e)
-            logger.error(f"Error generating answer with LLM: {error_msg}")
-
-            if "token" in error_msg.lower() and ("exceed" in error_msg.lower() or "limit" in error_msg.lower()):
-                return (
-                    "This repository is very large and exceeds the model's context window even after truncation. "
-                    "Try asking about a specific file or directory instead."
-                )
-            return f"An error occurred while generating the answer: {error_msg}"
+            logger.error("GitHub agent error for %s: %s", url, e)
+            return f"An error occurred while analysing the repository: {e}"

--- a/tools/github_crawler/__init__.py
+++ b/tools/github_crawler/__init__.py
@@ -1,9 +1,11 @@
 """
-GitHub Crawler - injectscs the github repo to a singular markdown file.
+GitHub Crawler — clones repos and traverses them with a ReAct agent.
 """
 
 from .convertor import convert_github_repo_to_markdown
+from .repo_agent import run_github_repo_agent
 
 __all__ = [
     "convert_github_repo_to_markdown",
+    "run_github_repo_agent",
 ]

--- a/tools/github_crawler/repo_agent.py
+++ b/tools/github_crawler/repo_agent.py
@@ -1,0 +1,249 @@
+"""
+GitHub Repo Agent — clones a repository and uses a ReAct sub-agent with bash/read/search
+tools to traverse the codebase and answer questions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Annotated, Any, Optional, Sequence, TypedDict
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.tools import StructuredTool
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode, tools_condition
+from pydantic import BaseModel, Field
+
+from core.llm import LargeLanguageModel
+
+_SYSTEM_PROMPT = """\
+You are an expert GitHub repository analyst. The repository has been cloned to: {repo_dir}
+
+Your task:
+1. Start by listing the root directory to understand the project structure.
+2. Read key files (README, package.json, pyproject.toml, main entry points, etc.).
+3. Search for relevant patterns or symbols when needed.
+4. Synthesize your findings into a clear, accurate answer referencing specific files and code.
+
+Be thorough but efficient — read what you need, then answer decisively.
+"""
+
+MAX_FILE_BYTES = 200_000
+MAX_SEARCH_LINES = 150
+
+
+class _BashInput(BaseModel):
+    command: str = Field(..., description="Bash command executed in the repository root directory.")
+    timeout: int = Field(default=30, description="Timeout in seconds (max 60).")
+
+
+class _ReadFileInput(BaseModel):
+    path: str = Field(..., description="File path relative to repository root (e.g. 'src/main.py').")
+
+
+class _SearchInput(BaseModel):
+    pattern: str = Field(..., description="Grep regex pattern to search for.")
+    file_glob: str = Field(default="", description="Optional glob to limit files (e.g. '*.py', '*.ts').")
+
+
+def _make_repo_tools(repo_dir: str) -> list[StructuredTool]:
+    root = Path(repo_dir).resolve()
+
+    async def _bash(command: str, timeout: int = 30) -> str:
+        timeout = min(max(timeout, 1), 60)
+
+        def _run() -> str:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(root),
+            )
+            out = result.stdout or ""
+            if result.stderr:
+                out += f"\n[stderr]: {result.stderr.strip()}"
+            if result.returncode != 0:
+                out += f"\n[exit code {result.returncode}]"
+            return out.strip() or "(no output)"
+
+        try:
+            return await asyncio.to_thread(_run)
+        except subprocess.TimeoutExpired:
+            return f"Command timed out after {timeout}s."
+        except Exception as exc:
+            return f"bash error: {exc}"
+
+    async def _read_file(path: str) -> str:
+        try:
+            target = (root / path).resolve()
+            if not str(target).startswith(str(root)):
+                return "Error: path escapes repository root."
+            if not target.exists():
+                return f"File not found: {path}"
+            if not target.is_file():
+                return f"Not a file: {path}"
+            size = target.stat().st_size
+            if size > MAX_FILE_BYTES:
+                return (
+                    f"File is large ({size:,} bytes). Use bash with `head -n 100 {path}` "
+                    f"or `grep` to read specific sections."
+                )
+            return target.read_text(errors="replace")
+        except Exception as exc:
+            return f"read_file error: {exc}"
+
+    async def _search(pattern: str, file_glob: str = "") -> str:
+        cmd = ["grep", "-rn", "--color=never"]
+        if file_glob:
+            cmd += ["--include", file_glob]
+        cmd += [pattern, "."]
+
+        def _run() -> str:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=str(root),
+            )
+            out = result.stdout.strip()
+            if not out:
+                return "No matches found."
+            lines = out.splitlines()
+            if len(lines) > MAX_SEARCH_LINES:
+                lines = lines[:MAX_SEARCH_LINES]
+                lines.append(f"... output truncated (showing {MAX_SEARCH_LINES} of many matches)")
+            return "\n".join(lines)
+
+        try:
+            return await asyncio.to_thread(_run)
+        except subprocess.TimeoutExpired:
+            return "Search timed out."
+        except Exception as exc:
+            return f"search_files error: {exc}"
+
+    return [
+        StructuredTool(
+            name="bash",
+            description=(
+                "Run a bash command in the repository root directory. "
+                "Use for: ls, find, tree, cat, head, wc, file counts, etc."
+            ),
+            coroutine=_bash,
+            args_schema=_BashInput,
+        ),
+        StructuredTool(
+            name="read_file",
+            description="Read a file's full contents by its path relative to the repository root.",
+            coroutine=_read_file,
+            args_schema=_ReadFileInput,
+        ),
+        StructuredTool(
+            name="search_files",
+            description=(
+                "Search for a regex pattern across the repository using grep. "
+                "Optionally restrict to a file glob like '*.py' or '*.ts'."
+            ),
+            coroutine=_search,
+            args_schema=_SearchInput,
+        ),
+    ]
+
+
+class _State(TypedDict):
+    messages: Annotated[Sequence[BaseMessage], add_messages]
+
+
+def _extract_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            p.get("text", "") if isinstance(p, dict) else str(p) for p in content
+        )
+    try:
+        return json.dumps(content, default=str)
+    except Exception:
+        return str(content)
+
+
+async def run_github_repo_agent(
+    url: str,
+    question: str,
+    chat_history: Optional[list[dict[str, Any]]] = None,
+) -> str:
+    """
+    Clone a public GitHub repository, then run a ReAct sub-agent with bash/read/search
+    tools to traverse the codebase and answer the given question.
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="github_agent_")
+
+    try:
+        clone = await asyncio.to_thread(
+            subprocess.run,
+            ["git", "clone", "--depth=1", "--", url, tmp_dir],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if clone.returncode != 0:
+            return (
+                f"Could not clone the repository.\n"
+                f"Make sure the URL is correct and the repository is public.\n"
+                f"Details: {clone.stderr.strip()}"
+            )
+
+        tools = _make_repo_tools(tmp_dir)
+        llm = LargeLanguageModel().client.bind_tools(tools)
+        system_prompt = _SYSTEM_PROMPT.format(repo_dir=tmp_dir)
+
+        # Compose user message with optional history
+        if chat_history:
+            history_str = "\n".join(
+                f"{e.get('role', 'user')}: {e.get('content', '')}"
+                for e in chat_history
+                if isinstance(e, dict)
+            )
+            user_message = f"Previous conversation:\n{history_str}\n\nQuestion: {question}"
+        else:
+            user_message = question
+
+        async def _agent_node(state: _State) -> dict:
+            msgs = list(state["messages"])
+            if not msgs or not isinstance(msgs[0], SystemMessage):
+                msgs = [SystemMessage(content=system_prompt)] + msgs
+            response = await llm.ainvoke(msgs)
+            return {"messages": [response]}
+
+        workflow = StateGraph(_State)
+        workflow.add_node("agent", _agent_node)
+        workflow.add_node("tools", ToolNode(tools))
+        workflow.add_edge(START, "agent")
+        workflow.add_conditional_edges("agent", tools_condition, {"tools": "tools", END: END})
+        workflow.add_edge("tools", "agent")
+        graph = workflow.compile()
+
+        result = await graph.ainvoke({"messages": [HumanMessage(content=user_message)]})
+
+        for msg in reversed(result.get("messages", [])):
+            if isinstance(msg, AIMessage):
+                text = _extract_text(msg.content)
+                if text.strip():
+                    return text
+
+        return "The agent completed traversal but did not produce a response."
+
+    except subprocess.TimeoutExpired:
+        return "Repository cloning timed out. The repository may be too large or unreachable."
+    except Exception as exc:
+        return f"GitHub agent error: {exc}"
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

- **GitHub agent rewrite**: replaces the `gitingest` flat-dump approach with a `git clone --depth=1` + LangGraph ReAct sub-agent that has `bash`, `read_file`, and `search_files` tools. The agent traverses the repo autonomously — listing directories, reading files, grepping for patterns — before synthesising an answer. This eliminates context-window blowouts on large repos and grounds answers in code the agent actually read.

- **Skills autocomplete fix**: autocomplete suggestions were embedding the multi-word display name (e.g. `System Info Skill`) into the `/skill-run` command. The parser in `executeAgent.ts` splits on the first space, so the skill name was silently truncated to a single word and every execution returned 404. Suggestions now embed the single-word folder id (e.g. `system_info`); filtering still matches by both name and id for a good UX.

## Commits

1. `feat(github)` — replace gitingest with clone-and-traverse ReAct agent — closes #46  
2. `fix(skills)` — use skill id in autocomplete commands to fix multi-word name parsing — refs #43

## Test plan

- [ ] Ask a question about a public GitHub repo and verify the agent clones, traverses files, and returns a grounded answer referencing specific paths
- [ ] Confirm temp clone dir is cleaned up after each run
- [ ] Type `/skill-run` and verify autocomplete shows skill ids (e.g. `/skill-run system_info`)
- [ ] Execute a skill with a multi-word display name and verify it resolves correctly (no 404)
- [ ] Verify existing non-skill agents are unaffected