### PR TITLE
feat: add OAuth settings management and debug UI refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local-only secrets
+.oauth_encryption_key
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/core/config.py
+++ b/core/config.py
@@ -21,6 +21,11 @@ class Settings(BaseSettings):
     backend_host: str = "0.0.0.0"
     backend_port: int = 5454
 
+    # ── LLM defaults (overridable via DB AppSetting "llm.default") ────────────
+    default_llm_provider: str = "google"
+    default_llm_model: str = ""  # blank → use provider's default_model
+    default_llm_temperature: float = 0.4
+
     # ── LLM providers ─────────────────────────────────────────────────────────
     google_api_key: str = ""
     google_client_secret: str = ""

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -1,25 +1,63 @@
 from __future__ import annotations
 
 import base64
+import logging
 import os
 from functools import lru_cache
+from pathlib import Path
 
 from Crypto.Cipher import AES
 
 from core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Bootstrap key file. Persisted alongside the project so a single-user dev
+# install works out of the box; users who care can override via env.
+_KEY_FILE = Path(__file__).resolve().parent.parent / ".oauth_encryption_key"
 
 
 class CryptoNotConfigured(RuntimeError):
     pass
 
 
+def _generate_key() -> str:
+    return base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
+
+
+def _load_or_create_local_key() -> str | None:
+    try:
+        if _KEY_FILE.exists():
+            text = _KEY_FILE.read_text().strip()
+            if text:
+                return text
+        # Generate a new one and persist it (chmod 600).
+        key = _generate_key()
+        _KEY_FILE.write_text(key + "\n")
+        try:
+            os.chmod(_KEY_FILE, 0o600)
+        except OSError:
+            pass
+        logger.warning(
+            "OAUTH_ENCRYPTION_KEY was not set; generated one and saved to %s. "
+            "For production set OAUTH_ENCRYPTION_KEY in env to a stable value.",
+            _KEY_FILE,
+        )
+        return key
+    except OSError:
+        logger.exception("Failed to read/create local oauth encryption key file")
+        return None
+
+
 @lru_cache(maxsize=1)
 def _key() -> bytes:
     raw = get_settings().oauth_encryption_key or os.environ.get("OAUTH_ENCRYPTION_KEY", "")
     if not raw:
+        raw = _load_or_create_local_key() or ""
+    if not raw:
         raise CryptoNotConfigured(
-            "OAUTH_ENCRYPTION_KEY is not set. Generate one with: "
-            "python -c \"import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())\""
+            "OAUTH_ENCRYPTION_KEY is not set and a local key file could not be created. "
+            "Set OAUTH_ENCRYPTION_KEY in your environment to a 32-byte base64-url value."
         )
     try:
         key = base64.urlsafe_b64decode(raw)

--- a/core/llm.py
+++ b/core/llm.py
@@ -211,8 +211,13 @@ def _build_default(
     temperature: float | None = None,
     api_key: str | None = None,
 ) -> LargeLanguageModel:
-    p = (provider or "google").lower()
+    s = get_settings()
+    p = (provider or s.default_llm_provider or "google").lower()
     cfg = PROVIDER_CONFIGS.get(p, PROVIDER_CONFIGS["google"])
+    if model is None and s.default_llm_model:
+        model = s.default_llm_model
+    if temperature is None:
+        temperature = s.default_llm_temperature
     if api_key is None:
         # Sync path: env/settings only. The async reload_default_llm()
         # rebinds with DB-resolved values at startup and on settings changes.

--- a/core/llm.py
+++ b/core/llm.py
@@ -196,21 +196,35 @@ class LargeLanguageModel:
 _default: LargeLanguageModel | None = None
 
 
+_PROVIDER_TO_SECRET = {
+    "google": "google_api_key",
+    "openai": "openai_api_key",
+    "anthropic": "anthropic_api_key",
+    "deepseek": "deepseek_api_key",
+    "openrouter": "openrouter_api_key",
+}
+
+
 def _build_default(
     provider: str | None = None,
     model: str | None = None,
     temperature: float | None = None,
+    api_key: str | None = None,
 ) -> LargeLanguageModel:
-    s = get_settings()
     p = (provider or "google").lower()
     cfg = PROVIDER_CONFIGS.get(p, PROVIDER_CONFIGS["google"])
-    api_key_attr = cfg.get("param_map", {}).get("api_key")
-    api_key = ""
-    if api_key_attr and hasattr(s, api_key_attr):
-        api_key = getattr(s, api_key_attr) or ""
+    if api_key is None:
+        # Sync path: env/settings only. The async reload_default_llm()
+        # rebinds with DB-resolved values at startup and on settings changes.
+        secret_name = _PROVIDER_TO_SECRET.get(p)
+        try:
+            from services.secrets_service import get_secrets_service
+            api_key = get_secrets_service().resolve_sync(secret_name) if secret_name else ""
+        except Exception:
+            api_key = getattr(get_settings(), secret_name, "") if secret_name else ""
     return LargeLanguageModel(
         model_name=model or cfg.get("default_model"),
-        api_key=api_key,
+        api_key=api_key or "",
         provider=p,  # type: ignore[arg-type]
         temperature=temperature if temperature is not None else 0.4,
     )
@@ -232,18 +246,28 @@ async def reload_default_llm() -> LargeLanguageModel:
         override = await AppStateService().get_setting("llm.default")
     except Exception:
         override = None
+    provider = (override or {}).get("provider")
+    api_key: str | None = None
+    secret_name = _PROVIDER_TO_SECRET.get((provider or "google").lower())
+    if secret_name:
+        try:
+            from services.secrets_service import get_secrets_service
+            api_key = await get_secrets_service().resolve(secret_name)
+        except Exception:
+            api_key = None
     if override:
         try:
             _default = _build_default(
-                provider=override.get("provider"),
+                provider=provider,
                 model=override.get("model"),
                 temperature=override.get("temperature"),
+                api_key=api_key,
             )
         except Exception as exc:
             print(f"Failed to apply LLM override {override!r}, falling back to env defaults: {exc}")
-            _default = _build_default()
+            _default = _build_default(api_key=api_key)
     else:
-        _default = _build_default()
+        _default = _build_default(api_key=api_key)
     return _default
 
 

--- a/debug/package.json
+++ b/debug/package.json
@@ -13,14 +13,21 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.168.25",
+    "html-react-parser": "^6.0.1",
     "lucide-react": "^0.468.0",
+    "markdown-it": "^14.1.1",
+    "markdown-it-task-lists": "^2.1.1",
+    "mermaid": "^11.14.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-force-graph-2d": "^1.26.6"
+    "react-force-graph-2d": "^1.26.6",
+    "react-syntax-highlighter": "^16.1.1"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.1.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.6.3",
     "vite": "^6.0.3"

--- a/debug/pnpm-lock.yaml
+++ b/debug/pnpm-lock.yaml
@@ -17,9 +17,21 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.168.25
         version: 1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      html-react-parser:
+        specifier: ^6.0.1
+        version: 6.0.1(@types/react@18.3.28)(react@18.3.1)
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@18.3.1)
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
+      markdown-it-task-lists:
+        specifier: ^2.1.1
+        version: 2.1.1
+      mermaid:
+        specifier: ^11.14.0
+        version: 11.14.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -29,13 +41,22 @@ importers:
       react-force-graph-2d:
         specifier: ^1.26.6
         version: 1.29.1(react@18.3.1)
+      react-syntax-highlighter:
+        specifier: ^16.1.1
+        version: 16.1.1(react@18.3.1)
     devDependencies:
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.28
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.7(@types/react@18.3.28)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2)
@@ -47,6 +68,9 @@ importers:
         version: 6.4.2
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -119,6 +143,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -130,6 +158,24 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/cst-dts-gen@12.0.0':
+    resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
+
+  '@chevrotain/gast@12.0.0':
+    resolution: {integrity: sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==}
+
+  '@chevrotain/regexp-to-ast@12.0.0':
+    resolution: {integrity: sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==}
+
+  '@chevrotain/types@12.0.0':
+    resolution: {integrity: sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==}
+
+  '@chevrotain/utils@12.0.0':
+    resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -287,6 +333,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.1':
+    resolution: {integrity: sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -302,6 +354,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mermaid-js/parser@1.1.0':
+    resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -650,8 +705,119 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -661,8 +827,23 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
+  '@types/react-syntax-highlighter@15.5.13':
+    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
+
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -673,6 +854,14 @@ packages:
   accessor-fn@1.5.3:
     resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
     engines: {node: '>=12'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -698,24 +887,99 @@ packages:
     resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
     engines: {node: '>=12'}
 
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chevrotain-allstar@0.4.1:
+    resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
+    peerDependencies:
+      chevrotain: ^12.0.0
+
+  chevrotain@12.0.0:
+    resolution: {integrity: sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==}
+    engines: {node: '>=22.0.0'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.2:
+    resolution: {integrity: sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
   d3-binarytree@1.0.2:
     resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
 
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
     engines: {node: '>=12'}
 
   d3-dispatch@3.0.1:
@@ -726,16 +990,37 @@ packages:
     resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
     engines: {node: '>=12'}
 
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
     engines: {node: '>=12'}
 
   d3-force-3d@3.0.6:
     resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
     engines: {node: '>=12'}
 
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
   d3-format@3.1.2:
     resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
     engines: {node: '>=12'}
 
   d3-interpolate@3.0.1:
@@ -745,9 +1030,27 @@ packages:
   d3-octree@1.1.0:
     resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
 
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
   d3-quadtree@3.0.1:
     resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
     engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
 
   d3-scale-chromatic@3.1.0:
     resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
@@ -759,6 +1062,13 @@ packages:
 
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
 
   d3-time-format@4.1.0:
@@ -783,6 +1093,16 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -792,11 +1112,44 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  dom-serializer@3.0.0:
+    resolution: {integrity: sha512-x+9D6nkC8tdXOQUS32egtZpZFLP90+HBZmWjuT920srbJvD/zPgFB9t4k3pEhlw5BQrXStQtRc1Y1zuriXk+Nw==}
+    engines: {node: '>=20.19.0'}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -806,6 +1159,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  fault@1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -824,6 +1180,10 @@ packages:
     resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
     engines: {node: '>=12'}
 
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -837,13 +1197,66 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  highlightjs-vue@1.0.0:
+    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
+
+  html-dom-parser@7.0.1:
+    resolution: {integrity: sha512-loRBDTCY/05/jAC63J1X9ID+xjRucmpLkIcQO0IRbOubBo5ucnpUpyXXob9UMXOskMZlu7KPsDP/2KOMelzJNA==}
+
+  html-react-parser@6.0.1:
+    resolution: {integrity: sha512-tIie2HSIk2Ct1tdupjd/DhBjskxN/NL5J4ncbUnk2smBr5UIfpPpitUo0imGfBM0BlOL7ac8RcqEwne1jXTcsQ==}
+    peerDependencies:
+      '@types/react': 0.14 || 15 || 16 || 17 || 18 || 19
+      react: 0.14 || 15 || 16 || 17 || 18 || 19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   index-array-by@1.4.2:
     resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
     engines: {node: '>=12'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   isbot@5.1.39:
     resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
@@ -870,12 +1283,35 @@ packages:
     resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
     engines: {node: '>=12'}
 
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  langium@4.2.2:
+    resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lowlight@1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -884,6 +1320,27 @@ packages:
     resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  mermaid@11.14.0:
+    resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -900,12 +1357,33 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -914,8 +1392,19 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -936,6 +1425,9 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.13.1'
+
+  react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -971,14 +1463,35 @@ packages:
       '@types/react':
         optional: true
 
+  react-syntax-highlighter@16.1.1:
+    resolution: {integrity: sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==}
+    engines: {node: '>= 16.20.2'}
+    peerDependencies:
+      react: '>= 0.14.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  refractor@5.0.0:
+    resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1001,12 +1514,32 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1015,6 +1548,12 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1046,6 +1585,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -1087,10 +1630,35 @@ packages:
       yaml:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1181,6 +1749,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -1203,6 +1773,23 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/cst-dts-gen@12.0.0':
+    dependencies:
+      '@chevrotain/gast': 12.0.0
+      '@chevrotain/types': 12.0.0
+
+  '@chevrotain/gast@12.0.0':
+    dependencies:
+      '@chevrotain/types': 12.0.0
+
+  '@chevrotain/regexp-to-ast@12.0.0': {}
+
+  '@chevrotain/types@12.0.0': {}
+
+  '@chevrotain/utils@12.0.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1282,6 +1869,14 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.1':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      mlly: 1.8.2
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1300,6 +1895,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mermaid-js/parser@1.1.0':
+    dependencies:
+      langium: 4.2.2
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -1578,7 +2177,141 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/prismjs@1.26.6': {}
 
   '@types/prop-types@15.7.15': {}
 
@@ -1586,10 +2319,26 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
+  '@types/react-syntax-highlighter@15.5.13':
+    dependencies:
+      '@types/react': 18.3.28
+
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
     dependencies:
@@ -1604,6 +2353,10 @@ snapshots:
       - supports-color
 
   accessor-fn@1.5.3: {}
+
+  acorn@8.16.0: {}
+
+  argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
@@ -1627,19 +2380,92 @@ snapshots:
     dependencies:
       tinycolor2: 1.6.0
 
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  chevrotain-allstar@0.4.1(chevrotain@12.0.0):
+    dependencies:
+      chevrotain: 12.0.0
+      lodash-es: 4.18.1
+
+  chevrotain@12.0.0:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 12.0.0
+      '@chevrotain/gast': 12.0.0
+      '@chevrotain/regexp-to-ast': 12.0.0
+      '@chevrotain/types': 12.0.0
+      '@chevrotain/utils': 12.0.0
+
+  comma-separated-tokens@2.0.3: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
+  confbox@0.1.8: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.2):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.2
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.2):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.2
+
+  cytoscape@3.33.2: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
 
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
 
+  d3-axis@3.0.0: {}
+
   d3-binarytree@1.0.2: {}
 
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
 
   d3-dispatch@3.0.1: {}
 
@@ -1648,7 +2474,17 @@ snapshots:
       d3-dispatch: 3.0.1
       d3-selection: 3.0.0
 
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
   d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
 
   d3-force-3d@3.0.6:
     dependencies:
@@ -1658,7 +2494,19 @@ snapshots:
       d3-quadtree: 3.0.1
       d3-timer: 3.0.1
 
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@3.0.1:
     dependencies:
@@ -1666,7 +2514,20 @@ snapshots:
 
   d3-octree@1.1.0: {}
 
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
   d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
 
   d3-scale-chromatic@3.1.0:
     dependencies:
@@ -1682,6 +2543,14 @@ snapshots:
       d3-time-format: 4.1.0
 
   d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
 
   d3-time-format@4.1.0:
     dependencies:
@@ -1710,13 +2579,87 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.20: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   detect-node-es@1.1.0: {}
 
+  dom-serializer@3.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
+  domelementtype@3.0.0: {}
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
+
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.0.0
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+
   electron-to-chromium@1.5.344: {}
+
+  entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1749,6 +2692,10 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  fault@1.0.4:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1777,6 +2724,8 @@ snapshots:
       kapsule: 1.16.3
       lodash-es: 4.18.1
 
+  format@0.2.2: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -1784,9 +2733,68 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  hachure-fill@0.5.2: {}
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
+  highlight.js@10.7.3: {}
+
+  highlightjs-vue@1.0.0: {}
+
+  html-dom-parser@7.0.1:
+    dependencies:
+      domhandler: 6.0.1
+      htmlparser2: 12.0.0
+
+  html-react-parser@6.0.1(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      domhandler: 6.0.1
+      html-dom-parser: 7.0.1
+      react: 18.3.1
+      react-property: 2.0.2
+      style-to-js: 1.1.21
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   index-array-by@1.4.2: {}
 
+  inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
   internmap@2.0.3: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
 
   isbot@5.1.39: {}
 
@@ -1802,11 +2810,39 @@ snapshots:
     dependencies:
       lodash-es: 4.18.1
 
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
+  langium@4.2.2:
+    dependencies:
+      '@chevrotain/regexp-to-ast': 12.0.0
+      chevrotain: 12.0.0
+      chevrotain-allstar: 0.4.1(chevrotain@12.0.0)
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   lodash-es@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lowlight@1.20.0:
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
 
   lru-cache@5.1.1:
     dependencies:
@@ -1816,6 +2852,52 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  marked@16.4.2: {}
+
+  mdurl@2.0.0: {}
+
+  mermaid@11.14.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.1
+      '@mermaid-js/parser': 1.1.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.2
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.2)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.2)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.1
+      katex: 0.16.45
+      khroma: 2.1.0
+      lodash-es: 4.18.1
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 11.1.1
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1824,9 +2906,38 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  package-manager-detector@1.6.0: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  path-data-parser@0.1.0: {}
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.12:
     dependencies:
@@ -1836,11 +2947,17 @@ snapshots:
 
   preact@10.29.1: {}
 
+  prismjs@1.30.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@7.1.0: {}
+
+  punycode.js@2.3.1: {}
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -1861,6 +2978,8 @@ snapshots:
     dependencies:
       jerrypick: 1.1.2
       react: 18.3.1
+
+  react-property@2.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -1891,9 +3010,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  react-syntax-highlighter@16.1.1(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      highlight.js: 10.7.3
+      highlightjs-vue: 1.0.0
+      lowlight: 1.20.0
+      prismjs: 1.30.0
+      react: 18.3.1
+      refractor: 5.0.0
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  refractor@5.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/prismjs': 1.26.6
+      hastscript: 9.0.1
+      parse-entities: 4.0.2
+
+  robust-predicates@3.0.3: {}
 
   rollup@4.60.2:
     dependencies:
@@ -1926,6 +3064,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -1940,16 +3089,36 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  stylis@4.4.0: {}
+
   tinycolor2@1.6.0: {}
+
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  ts-dedent@2.2.0: {}
+
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  ufo@1.6.4: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -1976,6 +3145,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  uuid@11.1.1: {}
+
   vite@6.4.2:
     dependencies:
       esbuild: 0.25.12
@@ -1986,5 +3157,22 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.1.0: {}
 
   yallist@3.1.1: {}

--- a/debug/src/components/MemoryGraph.tsx
+++ b/debug/src/components/MemoryGraph.tsx
@@ -218,7 +218,6 @@ export default function MemoryGraph({ claims }: { claims: Claim[] }) {
   const hubLineColor = isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.08)";
   const textColorPrimary = isLight ? "#09090b" : "#ffffff";
   const textColorMuted = isLight ? "#71717a" : "#a1a1aa";
-  const nodeOutline = isLight ? "#ffffff" : "#09090b";
 
   const numClusters = segments.length;
 

--- a/debug/src/components/RunsPanel.tsx
+++ b/debug/src/components/RunsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { api, type Run, type RunEvent } from "../lib/api";
+import MarkdownRenderer from "./ui/MarkdownRenderer";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -23,6 +24,76 @@ function timeAgo(iso: string) {
   if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
   if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
   return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+function parseResultText(raw: string | undefined | null): string {
+  if (!raw) return "";
+  const s = raw.trim();
+
+  // Helper to recursively extract text blocks from parsed objects
+  const extractText = (obj: any): string[] => {
+    if (Array.isArray(obj)) return obj.flatMap(extractText);
+    if (obj && typeof obj === "object") {
+      if (obj.type === "text" && typeof obj.text === "string") return [obj.text];
+      // Also handle {text: "..."} without type field
+      if (typeof obj.text === "string" && Object.keys(obj).length <= 2) return [obj.text];
+    }
+    if (typeof obj === "string") return [obj];
+    return [];
+  };
+
+  // Strategy 1: Direct JSON.parse
+  try {
+    const parsed = JSON.parse(s);
+    if (typeof parsed === "object" && parsed !== null) {
+      const texts = extractText(parsed);
+      if (texts.length > 0) return texts.join("\n\n");
+    }
+    if (typeof parsed === "string") return parsed;
+  } catch (_) { /* continue */ }
+
+  // Strategy 2: Python repr — single quotes like [{'type': 'text', 'text': '...'}]
+  // Convert Python-style single-quoted dicts to JSON
+  if (s.startsWith("[{") || s.startsWith("{'")) {
+    try {
+      // Replace Python single quotes with double quotes (careful with apostrophes)
+      const jsonified = s
+        .replace(/'/g, '"')
+        .replace(/"s\b/g, "'s") // restore common apostrophes
+        .replace(/\\n/g, "\n");
+      const parsed = JSON.parse(jsonified);
+      const texts = extractText(parsed);
+      if (texts.length > 0) return texts.join("\n\n");
+    } catch (_) { /* continue */ }
+  }
+
+  // Strategy 3: Regex extraction — grab text from "text": "..." or 'text': '...' patterns
+  // This handles truncated/broken JSON gracefully
+  const textBlockPattern = /["']text["']\s*:\s*["']((?:[^"'\\]|\\.)*)["']/g;
+  const matches: string[] = [];
+  let m;
+  while ((m = textBlockPattern.exec(s)) !== null) {
+    const decoded = m[1]
+      .replace(/\\n/g, "\n")
+      .replace(/\\t/g, "\t")
+      .replace(/\\"/g, '"')
+      .replace(/\\'/g, "'")
+      .replace(/\\\\/g, "\\");
+    if (decoded.length > 10) matches.push(decoded);
+  }
+  if (matches.length > 0) return matches.join("\n\n");
+
+  // Strategy 4: Strip leading [{"type": "text", "text": " wrapper if present
+  const wrapperMatch = s.match(/^\[?\{?["']?type["']?\s*:\s*["']text["']\s*,\s*["']text["']\s*:\s*["']([\s\S]+)$/);
+  if (wrapperMatch) {
+    let text = wrapperMatch[1];
+    // Remove trailing "}] or similar
+    text = text.replace(/["']\s*\}?\]?\s*$/, "");
+    text = text.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, '"');
+    if (text.length > 10) return text;
+  }
+
+  return raw;
 }
 
 // ── Status badge ─────────────────────────────────────────────────────────────
@@ -435,31 +506,47 @@ function RunDetail({
 
       {/* Result / Error banner */}
       {(run.final_answer || run.error) && (
-        <div
-          style={{
-            margin: "0 20px 24px 20px",
-            padding: "12px 16px",
-            border: "1px solid var(--border-color)",
-            borderRadius: 8,
+        <div className="run-result-card" style={{
+          margin: "0 20px 20px 20px",
+          borderRadius: 10,
+          border: `1px solid ${run.error ? "rgba(248,113,113,0.25)" : "var(--border-color)"}`,
+          background: run.error ? "rgba(248,113,113,0.04)" : "var(--card-bg)",
+          overflow: "hidden",
+          flexShrink: 0,
+        }}>
+          <div style={{
+            padding: "10px 16px",
+            borderBottom: "1px solid var(--border-color)",
             display: "flex",
-            gap: 16,
-            flexShrink: 0,
-          }}
-        >
-          <span
-            style={{
-              fontSize: 10,
+            alignItems: "center",
+            gap: 8,
+            background: run.error ? "rgba(248,113,113,0.06)" : "var(--input-bg)",
+          }}>
+            <span style={{
+              width: 6, height: 6, borderRadius: "50%",
+              background: run.error ? "var(--rose)" : "var(--green)",
+              flexShrink: 0,
+            }} />
+            <span style={{
+              fontSize: 11,
               fontWeight: 600,
-              letterSpacing: "0.1em",
-              color: "var(--text-muted)",
-              marginTop: 2,
-            }}
-          >
-            {run.error ? "ERROR" : "RESULT"}
-          </span>
-          <span style={{ fontSize: 13, color: "var(--text-primary)", lineHeight: 1.5 }}>
-            {run.error ?? run.final_answer}
-          </span>
+              letterSpacing: "0.08em",
+              color: run.error ? "var(--rose)" : "var(--text-muted)",
+              textTransform: "uppercase",
+            }}>
+              {run.error ? "Error" : "Final Result"}
+            </span>
+          </div>
+          <div style={{
+            padding: "16px 20px",
+            maxHeight: "40vh",
+            overflow: "auto",
+            fontSize: 13,
+            lineHeight: 1.65,
+            color: "var(--text-primary)",
+          }}>
+            <MarkdownRenderer content={parseResultText(run.error ?? run.final_answer)} />
+          </div>
         </div>
       )}
 
@@ -511,22 +598,59 @@ function RunDetail({
               No subagents for this run.
             </p>
           ) : (
-            <div style={{ padding: "24px 20px", display: "flex", flexDirection: "column", gap: 32 }}>
+            <div style={{ padding: "16px 20px", display: "flex", flexDirection: "column", gap: 16 }}>
               {run.subagents.map((s) => (
-                <div key={s.subagent_run_id} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <div key={s.subagent_run_id} style={{
+                  borderRadius: 10,
+                  border: "1px solid var(--border-color)",
+                  background: "var(--card-bg)",
+                  overflow: "hidden",
+                }}>
+                  {/* Subagent header */}
+                  <div style={{
+                    padding: "12px 16px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    background: "var(--input-bg)",
+                    borderBottom: "1px solid var(--border-color)",
+                  }}>
                     <StatusBadge status={s.status} />
-                    <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text-primary)" }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-primary)", flex: 1 }}>
                       {s.name}
                     </span>
                   </div>
-                  <p style={{ fontSize: 13, color: "var(--text-secondary)", lineHeight: 1.5, margin: 0 }}>
+                  {/* Task */}
+                  <div style={{
+                    padding: "12px 16px",
+                    fontSize: 12,
+                    color: "var(--text-muted)",
+                    lineHeight: 1.5,
+                    borderBottom: s.result ? "1px solid var(--border-color)" : "none",
+                  }}>
+                    <span style={{
+                      fontSize: 9,
+                      fontWeight: 700,
+                      letterSpacing: "0.1em",
+                      color: "var(--text-faint)",
+                      textTransform: "uppercase" as const,
+                      display: "block",
+                      marginBottom: 6,
+                    }}>Task</span>
                     {s.task}
-                  </p>
+                  </div>
+                  {/* Result */}
                   {s.result && (
-                    <p style={{ fontSize: 13, color: "var(--text-muted)", lineHeight: 1.5, margin: 0, wordBreak: "break-word" }}>
-                      {s.result}
-                    </p>
+                    <div style={{
+                      padding: "16px 20px",
+                      fontSize: 13,
+                      lineHeight: 1.65,
+                      color: "var(--text-primary)",
+                      maxHeight: "50vh",
+                      overflow: "auto",
+                    }}>
+                      <MarkdownRenderer content={parseResultText(s.result)} />
+                    </div>
                   )}
                 </div>
               ))}

--- a/debug/src/components/SettingsPanel.tsx
+++ b/debug/src/components/SettingsPanel.tsx
@@ -3,8 +3,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   api,
   type IntegrationsStatus,
-  type LLMEffective,
   type OAuthConnection,
+  type OAuthClientStatus,
+  type SecretStatus,
+  type ComposioConfigPublic,
+  type PyJIITPublic,
 } from "../lib/api";
 
 const COMPOSIO_SUGGESTED = ["linkedin", "gmail", "google_calendar", "github", "notion", "slack"];
@@ -12,9 +15,11 @@ const COMPOSIO_SUGGESTED = ["linkedin", "gmail", "google_calendar", "github", "n
 function StatusPill({
   ok,
   label,
+  onClick,
 }: {
   ok: boolean | null;
   label: string;
+  onClick?: () => void;
 }) {
   const bg = ok === true
     ? "var(--status-connected-bg)"
@@ -28,6 +33,7 @@ function StatusPill({
       : "var(--text-muted)";
   return (
     <span
+      onClick={onClick}
       style={{
         display: "inline-flex",
         alignItems: "center",
@@ -39,6 +45,7 @@ function StatusPill({
         background: bg,
         color,
         border: `1px solid ${color}`,
+        cursor: onClick ? "pointer" : "default",
       }}
     >
       <span style={{ width: 6, height: 6, borderRadius: "50%", background: color }} />
@@ -105,7 +112,120 @@ function btnStyle(variant: "primary" | "danger" | "ghost" = "ghost"): React.CSSP
   return { ...common, background: "var(--input-bg)", color: "var(--text-primary)" };
 }
 
-function OAuthSection({ oauth, onChange }: { oauth: OAuthConnection[]; onChange: () => void }) {
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "6px 10px",
+  fontSize: 12,
+  borderRadius: 6,
+  border: "1px solid var(--border-color)",
+  background: "var(--input-bg)",
+  color: "var(--text-primary)",
+};
+
+type MutationLike = {
+  isPending: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: unknown;
+  variables?: unknown;
+  submittedAt?: number;
+};
+
+function MutationState({ m, label }: { m: MutationLike; label?: string }) {
+  if (m.isPending) {
+    return (
+      <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+        Saving{label ? ` ${label}` : ""}…
+      </span>
+    );
+  }
+  if (m.isError) {
+    const msg = m.error instanceof Error ? m.error.message : String(m.error);
+    return (
+      <span
+        style={{ fontSize: 11, color: "#dc2626", maxWidth: 320, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        title={msg}
+      >
+        ✗ {msg}
+      </span>
+    );
+  }
+  if (m.isSuccess) {
+    return <span style={{ fontSize: 11, color: "#16a34a" }}>✓ Saved</span>;
+  }
+  return null;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <span style={{ fontSize: 10, fontWeight: 600, color: "var(--text-muted)", letterSpacing: "0.05em" }}>
+        {label.toUpperCase()}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+// ── Modal ─────────────────────────────────────────────────────────────────────
+
+function Modal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--bg-color)",
+          border: "1px solid var(--border-color)",
+          borderRadius: 12,
+          padding: 20,
+          minWidth: 380,
+          maxWidth: 520,
+          width: "90%",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+          <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>{title}</h3>
+          <button onClick={onClose} style={btnStyle()}>
+            ×
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ── OAuth integrations (now with Connect button via web flow) ────────────────
+
+function OAuthSection({
+  oauth,
+  clients,
+  onChange,
+}: {
+  oauth: OAuthConnection[];
+  clients: OAuthClientStatus[];
+  onChange: () => void;
+}) {
   const disconnect = useMutation({
     mutationFn: (provider: string) => api.oauthDisconnect(provider),
     onSuccess: onChange,
@@ -113,11 +233,14 @@ function OAuthSection({ oauth, onChange }: { oauth: OAuthConnection[]; onChange:
 
   const providers = ["google", "github"];
   const byProvider = Object.fromEntries(oauth.map((c) => [c.provider, c]));
+  const clientByProvider = Object.fromEntries(clients.map((c) => [c.provider, c]));
 
   return (
     <Section title="OAuth integrations">
       {providers.map((p) => {
         const c = byProvider[p];
+        const client = clientByProvider[p];
+        const canConnect = client && client.client_id_source !== "unset" && client.client_secret_source !== "unset";
         return (
           <Row key={p}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
@@ -134,30 +257,143 @@ function OAuthSection({ oauth, onChange }: { oauth: OAuthConnection[]; onChange:
                   {c.expires_at && ` · expires ${new Date(c.expires_at).toLocaleString()}`}
                 </div>
               )}
-              {!c && (
+              {!c && !canConnect && (
                 <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
-                  Sign in via the browser extension to connect.
+                  Configure client_id and client_secret below first.
                 </div>
               )}
             </div>
-            {c && (
-              <button
-                style={btnStyle("danger")}
-                onClick={() => disconnect.mutate(p)}
-                disabled={disconnect.isPending}
-              >
-                Disconnect
-              </button>
-            )}
+            <div style={{ display: "flex", gap: 6 }}>
+              {!c && canConnect && (
+                <a href={`/api/auth/${p}/start`} style={{ ...btnStyle("primary"), textDecoration: "none" }}>
+                  Connect
+                </a>
+              )}
+              {c && (
+                <button
+                  style={btnStyle("danger")}
+                  onClick={() => disconnect.mutate(p)}
+                  disabled={disconnect.isPending}
+                >
+                  Disconnect
+                </button>
+              )}
+            </div>
           </Row>
         );
       })}
+      <div style={{ marginTop: 8 }}>
+        <MutationState m={disconnect} label="disconnect" />
+      </div>
     </Section>
   );
 }
 
-function ComposioSection({ status, onChange }: { status: IntegrationsStatus["composio"]; onChange: () => void }) {
+// ── OAuth client setup (client_id / client_secret) ───────────────────────────
+
+function OAuthClientsSection({ clients, onChange }: { clients: OAuthClientStatus[]; onChange: () => void }) {
+  const [editing, setEditing] = useState<string | null>(null);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.oauthClientSet(editing!, {
+        client_id: clientId || undefined,
+        client_secret: clientSecret || undefined,
+      }),
+    onSuccess: () => {
+      setEditing(null);
+      setClientId("");
+      setClientSecret("");
+      onChange();
+    },
+  });
+  const clear = useMutation({
+    mutationFn: (provider: string) => api.oauthClientClear(provider),
+    onSuccess: onChange,
+  });
+
+  return (
+    <Section title="OAuth client setup">
+      {clients.map((c) => (
+        <Row key={c.provider}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <strong style={{ textTransform: "capitalize", fontSize: 13 }}>{c.provider}</strong>
+            <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              client_id ({c.client_id_source}): <code>{c.client_id_masked || "—"}</code>
+              {" · "}
+              client_secret ({c.client_secret_source}): <code>{c.client_secret_masked || "—"}</code>
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button style={btnStyle()} onClick={() => setEditing(c.provider)}>Edit</button>
+            {(c.client_id_source === "db" || c.client_secret_source === "db") && (
+              <button style={btnStyle("danger")} onClick={() => clear.mutate(c.provider)} disabled={clear.isPending}>
+                Reset
+              </button>
+            )}
+          </div>
+        </Row>
+      ))}
+
+      {editing && (
+        <Modal title={`Edit ${editing} OAuth client`} onClose={() => setEditing(null)}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <Field label="Client ID">
+              <input
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+                placeholder="Leave blank to keep existing"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Client secret">
+              <input
+                type="password"
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
+                placeholder="Leave blank to keep existing"
+                style={inputStyle}
+              />
+            </Field>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+              <MutationState m={save} />
+              <button style={btnStyle()} onClick={() => setEditing(null)}>Cancel</button>
+              <button
+                style={btnStyle("primary")}
+                disabled={(!clientId && !clientSecret) || save.isPending}
+                onClick={() => save.mutate()}
+              >
+                {save.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+      <div style={{ marginTop: 8 }}>
+        <MutationState m={clear} label="reset" />
+      </div>
+    </Section>
+  );
+}
+
+// ── Composio (toolkits + config) ─────────────────────────────────────────────
+
+function ComposioSection({
+  status,
+  config,
+  onChange,
+}: {
+  status: IntegrationsStatus["composio"];
+  config: ComposioConfigPublic;
+  onChange: () => void;
+}) {
   const [toolkit, setToolkit] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [apiKey, setApiKey] = useState("");
+  const [userId, setUserId] = useState("");
+
   const connect = useMutation({
     mutationFn: (tk: string) => api.composioConnect(tk),
     onSuccess: (data) => {
@@ -169,83 +405,147 @@ function ComposioSection({ status, onChange }: { status: IntegrationsStatus["com
     mutationFn: (id: string) => api.composioDisconnect(id),
     onSuccess: onChange,
   });
-
-  if (!status.configured) {
-    return (
-      <Section title="Composio">
-        <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
-          Composio is not configured. Set <code>COMPOSIO_API_KEY</code> and <code>COMPOSIO_USER_ID</code> in your environment.
-        </div>
-      </Section>
-    );
-  }
+  const saveCfg = useMutation({
+    mutationFn: () =>
+      api.composioConfigSet({
+        api_key: apiKey || undefined,
+        user_id: userId || undefined,
+      }),
+    onSuccess: () => {
+      setEditing(false);
+      setApiKey("");
+      setUserId("");
+      onChange();
+    },
+  });
+  const clearCfg = useMutation({
+    mutationFn: () => api.composioConfigClear(),
+    onSuccess: onChange,
+  });
 
   return (
-    <Section title="Composio toolkits">
-      {status.error && (
-        <div style={{ fontSize: 11, color: "#dc2626", marginBottom: 10 }}>{status.error}</div>
-      )}
-      <div style={{ fontSize: 11, color: "var(--text-muted)", marginBottom: 12 }}>
-        User ID: <code>{status.user_id}</code>
-      </div>
-      {status.connected.length === 0 && (
-        <div style={{ fontSize: 12, color: "var(--text-muted)", padding: "10px 0" }}>
-          No connected toolkits.
-        </div>
-      )}
-      {status.connected.map((c) => (
-        <Row key={c.id || c.toolkit || Math.random()}>
+    <Section title="Composio">
+      <Row>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            <strong style={{ fontSize: 13 }}>{c.toolkit || "(unknown)"}</strong>
-            <StatusPill ok={c.status === "ACTIVE" || c.status === "active"} label={c.status || "?"} />
+            <strong style={{ fontSize: 13 }}>Configuration</strong>
+            <StatusPill ok={status.configured} label={status.configured ? "configured" : "missing"} />
           </div>
-          {c.id && (
-            <button
-              style={btnStyle("danger")}
-              onClick={() => disconnect.mutate(c.id!)}
-              disabled={disconnect.isPending}
-            >
-              Disconnect
+          <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+            api_key ({config.api_key_source}): <code>{config.api_key_masked || "—"}</code>
+            {" · "}
+            user_id ({config.user_id_source}): <code>{config.user_id || "—"}</code>
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button style={btnStyle()} onClick={() => setEditing(true)}>Edit</button>
+          {(config.api_key_source === "db" || config.user_id_source === "db") && (
+            <button style={btnStyle("danger")} onClick={() => clearCfg.mutate()} disabled={clearCfg.isPending}>
+              Reset
             </button>
           )}
-        </Row>
-      ))}
+        </div>
+      </Row>
 
-      <div style={{ marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--border-color)" }}>
-        <div style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>
-          CONNECT NEW TOOLKIT
-        </div>
-        <div style={{ display: "flex", gap: 8 }}>
-          <input
-            value={toolkit}
-            onChange={(e) => setToolkit(e.target.value)}
-            placeholder="e.g. linkedin, gmail, github"
-            list="composio-suggestions"
-            style={{
-              flex: 1,
-              padding: "6px 10px",
-              fontSize: 12,
-              borderRadius: 6,
-              border: "1px solid var(--border-color)",
-              background: "var(--input-bg)",
-              color: "var(--text-primary)",
-            }}
-          />
-          <datalist id="composio-suggestions">
-            {COMPOSIO_SUGGESTED.map((s) => <option key={s} value={s} />)}
-          </datalist>
-          <button
-            style={btnStyle("primary")}
-            disabled={!toolkit.trim() || connect.isPending}
-            onClick={() => connect.mutate(toolkit.trim())}
-          >
-            Connect
-          </button>
-        </div>
+      {status.configured && (
+        <>
+          {status.error && (
+            <div style={{ fontSize: 11, color: "#dc2626", marginTop: 10 }}>{status.error}</div>
+          )}
+          {status.connected.length === 0 && (
+            <div style={{ fontSize: 12, color: "var(--text-muted)", padding: "10px 0" }}>
+              No connected toolkits.
+            </div>
+          )}
+          {status.connected.map((c) => (
+            <Row key={c.id || c.toolkit || Math.random()}>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <strong style={{ fontSize: 13 }}>{c.toolkit || "(unknown)"}</strong>
+                <StatusPill ok={c.status === "ACTIVE" || c.status === "active"} label={c.status || "?"} />
+              </div>
+              {c.id && (
+                <button
+                  style={btnStyle("danger")}
+                  onClick={() => disconnect.mutate(c.id!)}
+                  disabled={disconnect.isPending}
+                >
+                  Disconnect
+                </button>
+              )}
+            </Row>
+          ))}
+
+          <div style={{ marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--border-color)" }}>
+            <div style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>
+              CONNECT NEW TOOLKIT
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+              <input
+                value={toolkit}
+                onChange={(e) => setToolkit(e.target.value)}
+                placeholder="e.g. linkedin, gmail, github"
+                list="composio-suggestions"
+                style={inputStyle}
+              />
+              <datalist id="composio-suggestions">
+                {COMPOSIO_SUGGESTED.map((s) => <option key={s} value={s} />)}
+              </datalist>
+              <button
+                style={btnStyle("primary")}
+                disabled={!toolkit.trim() || connect.isPending}
+                onClick={() => connect.mutate(toolkit.trim())}
+              >
+                Connect
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {editing && (
+        <Modal title="Composio configuration" onClose={() => setEditing(false)}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <Field label="API key">
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="Leave blank to keep existing"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="User ID">
+              <input
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                placeholder={config.user_id || "Leave blank to keep existing"}
+                style={inputStyle}
+              />
+            </Field>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+              <MutationState m={saveCfg} />
+              <button style={btnStyle()} onClick={() => setEditing(false)}>Cancel</button>
+              <button
+                style={btnStyle("primary")}
+                disabled={(!apiKey && !userId) || saveCfg.isPending}
+                onClick={() => saveCfg.mutate()}
+              >
+                {saveCfg.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+      <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 4 }}>
+        <MutationState m={connect} label="connect" />
+        <MutationState m={disconnect} label="disconnect" />
+        <MutationState m={clearCfg} label="reset" />
       </div>
     </Section>
   );
 }
+
+// ── LLM model + provider keys (with editable secrets) ────────────────────────
 
 function LLMSection({
   llm,
@@ -257,6 +557,8 @@ function LLMSection({
   const [provider, setProvider] = useState(llm.effective.provider);
   const [model, setModel] = useState(llm.effective.model);
   const [temperature, setTemperature] = useState(String(llm.effective.temperature ?? 0.4));
+  const [editingSecret, setEditingSecret] = useState<SecretStatus | null>(null);
+  const [secretValue, setSecretValue] = useState("");
 
   const set = useMutation({
     mutationFn: () =>
@@ -269,9 +571,19 @@ function LLMSection({
   });
   const clear = useMutation({
     mutationFn: () => api.llmClear(),
+    onSuccess: onChange,
+  });
+  const saveSecret = useMutation({
+    mutationFn: () => api.secretSet(editingSecret!.name, secretValue),
     onSuccess: () => {
+      setEditingSecret(null);
+      setSecretValue("");
       onChange();
     },
+  });
+  const clearSecret = useMutation({
+    mutationFn: (name: string) => api.secretClear(name),
+    onSuccess: onChange,
   });
 
   const providers = Object.keys(llm.providers_configured);
@@ -315,49 +627,196 @@ function LLMSection({
         </Field>
       </div>
 
-      <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
+      <div style={{ display: "flex", gap: 8, marginTop: 14, alignItems: "center" }}>
         <button style={btnStyle("primary")} onClick={() => set.mutate()} disabled={set.isPending}>
-          Save override
+          {set.isPending ? "Saving…" : "Save override"}
         </button>
         <button style={btnStyle()} onClick={() => clear.mutate()} disabled={clear.isPending}>
-          Reset to .env default
+          {clear.isPending ? "Resetting…" : "Reset to .env default"}
         </button>
+        <MutationState m={set} />
+        <MutationState m={clear} />
       </div>
 
       <div style={{ marginTop: 16, paddingTop: 14, borderTop: "1px solid var(--border-color)" }}>
         <div style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>
-          PROVIDER KEYS (.env)
+          PROVIDER KEYS · click to edit
         </div>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-          {Object.entries(llm.providers_configured).map(([p, ok]) => (
-            <StatusPill key={p} ok={ok} label={p} />
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {llm.secrets.map((s) => (
+            <div
+              key={s.name}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "6px 0",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <strong style={{ fontSize: 12 }}>{s.name}</strong>
+                <StatusPill
+                  ok={s.source === "db" ? true : s.source === "env" ? true : false}
+                  label={s.source === "db" ? "db" : s.source === "env" ? "env" : "unset"}
+                />
+                {s.masked && (
+                  <code style={{ fontSize: 11, color: "var(--text-muted)" }}>{s.masked}</code>
+                )}
+              </div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button
+                  style={btnStyle()}
+                  onClick={() => {
+                    setEditingSecret(s);
+                    setSecretValue("");
+                  }}
+                >
+                  Edit
+                </button>
+                {s.db_set && (
+                  <button
+                    style={btnStyle("danger")}
+                    onClick={() => clearSecret.mutate(s.name)}
+                    disabled={clearSecret.isPending}
+                  >
+                    Reset
+                  </button>
+                )}
+              </div>
+            </div>
           ))}
         </div>
+      </div>
+
+      <div style={{ marginTop: 8 }}>
+        <MutationState m={clearSecret} label="reset" />
+      </div>
+
+      {editingSecret && (
+        <Modal title={`Set ${editingSecret.name}`} onClose={() => setEditingSecret(null)}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              Stored encrypted. Overrides the <code>{editingSecret.env_var}</code> env var.
+            </div>
+            <Field label="Value">
+              <input
+                type="password"
+                value={secretValue}
+                onChange={(e) => setSecretValue(e.target.value)}
+                placeholder="Paste new value"
+                style={inputStyle}
+                autoFocus
+              />
+            </Field>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+              <MutationState m={saveSecret} />
+              <button style={btnStyle()} onClick={() => setEditingSecret(null)}>Cancel</button>
+              <button
+                style={btnStyle("primary")}
+                disabled={!secretValue || saveSecret.isPending}
+                onClick={() => saveSecret.mutate()}
+              >
+                {saveSecret.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </Section>
+  );
+}
+
+// ── PyJIIT ────────────────────────────────────────────────────────────────────
+
+function PyJIITSection({ pyjiit, onChange }: { pyjiit: PyJIITPublic; onChange: () => void }) {
+  const [editing, setEditing] = useState(false);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.pyjiitSet({
+        username: username || undefined,
+        password: password || undefined,
+      }),
+    onSuccess: () => {
+      setEditing(false);
+      setUsername("");
+      setPassword("");
+      onChange();
+    },
+  });
+  const clear = useMutation({
+    mutationFn: () => api.pyjiitClear(),
+    onSuccess: onChange,
+  });
+
+  return (
+    <Section title="PyJIIT (J-Portal)">
+      <Row>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <strong style={{ fontSize: 13 }}>Credentials</strong>
+            <StatusPill ok={pyjiit.configured} label={pyjiit.configured ? "configured" : "not set"} />
+          </div>
+          <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+            username: <code>{pyjiit.username || "—"}</code>
+            {" · "}
+            password: <code>{pyjiit.password_masked || "—"}</code>
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button style={btnStyle()} onClick={() => setEditing(true)}>Edit</button>
+          {pyjiit.configured && (
+            <button style={btnStyle("danger")} onClick={() => clear.mutate()} disabled={clear.isPending}>
+              Reset
+            </button>
+          )}
+        </div>
+      </Row>
+
+      {editing && (
+        <Modal title="PyJIIT credentials" onClose={() => setEditing(false)}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <Field label="Enrolment number / username">
+              <input
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder={pyjiit.username || "Leave blank to keep existing"}
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Password">
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Leave blank to keep existing"
+                style={inputStyle}
+              />
+            </Field>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+              <MutationState m={save} />
+              <button style={btnStyle()} onClick={() => setEditing(false)}>Cancel</button>
+              <button
+                style={btnStyle("primary")}
+                disabled={(!username && !password) || save.isPending}
+                onClick={() => save.mutate()}
+              >
+                {save.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+      <div style={{ marginTop: 8 }}>
+        <MutationState m={clear} label="reset" />
       </div>
     </Section>
   );
 }
 
-const inputStyle: React.CSSProperties = {
-  width: "100%",
-  padding: "6px 10px",
-  fontSize: 12,
-  borderRadius: 6,
-  border: "1px solid var(--border-color)",
-  background: "var(--input-bg)",
-  color: "var(--text-primary)",
-};
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-      <span style={{ fontSize: 10, fontWeight: 600, color: "var(--text-muted)", letterSpacing: "0.05em" }}>
-        {label.toUpperCase()}
-      </span>
-      {children}
-    </div>
-  );
-}
+// ── Native tools / agents / infra (unchanged) ────────────────────────────────
 
 function NativeToolsSection({ tools }: { tools: IntegrationsStatus["native_tools"] }) {
   return (
@@ -428,9 +887,11 @@ export function SettingsPanel() {
 
   return (
     <div style={{ overflow: "auto", padding: 30, height: "100%" }}>
-      <OAuthSection oauth={data.oauth} onChange={onChange} />
+      <OAuthSection oauth={data.oauth} clients={data.oauth_clients} onChange={onChange} />
+      <OAuthClientsSection clients={data.oauth_clients} onChange={onChange} />
       <LLMSection llm={data.llm} onChange={onChange} />
-      <ComposioSection status={data.composio} onChange={onChange} />
+      <ComposioSection status={data.composio} config={data.composio_config} onChange={onChange} />
+      <PyJIITSection pyjiit={data.pyjiit} onChange={onChange} />
       <NativeToolsSection tools={data.native_tools} />
       <AgentsSection agents={data.agents} />
       <InfraSection infra={data.infra} />

--- a/debug/src/components/ui/MarkdownRenderer.tsx
+++ b/debug/src/components/ui/MarkdownRenderer.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useMarkdown } from "./useMarkdown";
+
+interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+const cn = (...classes: (string | undefined)[]) => classes.filter(Boolean).join(" ");
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className }) => {
+  const { renderedParts } = useMarkdown(content);
+
+  return (
+    <div className={cn("markdown-renderer", className)}>
+      {renderedParts}
+    </div>
+  );
+};
+
+export default MarkdownRenderer;

--- a/debug/src/components/ui/useMarkdown.tsx
+++ b/debug/src/components/ui/useMarkdown.tsx
@@ -1,0 +1,198 @@
+import React, { useMemo, useEffect } from "react";
+import MarkdownIt from "markdown-it";
+// @ts-expect-error missing types
+import taskLists from "markdown-it-task-lists";
+import parse, { Element } from "html-react-parser";
+import mermaid from "mermaid";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { Check, Copy, Terminal } from "lucide-react";
+
+// ============================================
+// COMPONENT: CodeBlock
+// ============================================
+const CodeBlock = ({ language, code }: { language: string; code: string }) => {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative group my-6 overflow-hidden rounded-xl border border-gray-700/50 bg-[#1e1e1e] shadow-2xl">
+      <div className="flex items-center justify-between px-4 py-2 bg-[#282c34] border-b border-gray-700/50">
+        <div className="flex items-center gap-2">
+          <Terminal className="w-4 h-4 text-gray-400" />
+          <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">
+            {language || "text"}
+          </span>
+        </div>
+        <button
+          onClick={handleCopy}
+          className="p-1.5 rounded-md hover:bg-gray-700/50 text-gray-400 hover:text-gray-200 transition-colors"
+        >
+          {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+        </button>
+      </div>
+      <SyntaxHighlighter
+        language={language.toLowerCase()}
+        style={oneDark}
+        customStyle={{ margin: 0, padding: "1.5rem", background: "transparent", fontSize: "0.9rem", lineHeight: "1.6" }}
+        showLineNumbers={true}
+        lineNumberStyle={{ minWidth: "2.5em", paddingRight: "1em", color: "#4b5563", borderRight: "1px solid #374151", marginRight: "1em" }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+};
+
+// ============================================
+// COMPONENT: MermaidBlock
+// ============================================
+const MermaidBlock = ({ code }: { code: string }) => {
+  const id = useMemo(() => `mermaid-${Math.random().toString(36).substring(2, 9)}`, []);
+
+  useEffect(() => {
+    mermaid.initialize({ startOnLoad: false, theme: "dark" });
+    setTimeout(() => {
+      mermaid.contentLoaded();
+      mermaid.init(undefined, `#${id}`);
+    }, 0);
+  }, [code, id]);
+
+  return (
+    <div className="flex justify-center my-6 overflow-hidden rounded-xl border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-[#1e1e1e] p-6 shadow-sm">
+      <div id={id} className="mermaid">
+        {code}
+      </div>
+    </div>
+  );
+};
+
+// ============================================
+// HOOK IMPLEMENTATION
+// ============================================
+export function useMarkdown(content: string) {
+  const slugify = (text: string) => text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)+/g, "");
+
+  const md = useMemo(() => {
+    const instance = new MarkdownIt({ html: true, linkify: true, typographer: true })
+      .use(taskLists, { label: true });
+
+    // 1. INTERCEPT CODE BLOCKS FOR REACT INJECTION
+    instance.renderer.rules.fence = (tokens, idx) => {
+      const lang = tokens[idx].info.trim();
+      const code = instance.utils.escapeHtml(tokens[idx].content);
+      
+      if (lang === "mermaid") return `<div data-mermaid-block="true">${code}</div>`;
+      return `<div data-code-block="true" data-language="${lang}">${code}</div>`;
+    };
+
+    // 2. GFM CALLOUTS PARSER (> [!NOTE])
+    instance.core.ruler.after('block', 'gfm_alerts', (state) => {
+      const tokens = state.tokens;
+      for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i].type === 'blockquote_open') {
+          const pOpen = tokens[i + 1];
+          const inline = tokens[i + 2];
+
+          if (pOpen?.type === 'paragraph_open' && inline?.type === 'inline') {
+            const match = inline.content.match(/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|DANGER)\]/i);
+            if (match) {
+              const type = match[1].toLowerCase();
+              tokens[i].attrJoin('class', `gfm-alert gfm-alert-${type}`);
+              
+              // Remove the indicator text
+              inline.content = inline.content.replace(/^\[!.*?\]\s*/, '');
+              if (inline.children?.[0]) {
+                inline.children[0].content = inline.children[0].content.replace(/^\[!.*?\]\s*/, '');
+              }
+
+              // Alert Title & Icon mapping
+              const titleHtml = new state.Token('html_inline', '', 0);
+              const icons: Record<string, string> = {
+                note: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>',
+                tip: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>',
+                warning: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>',
+                danger: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>',
+                caution: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>',
+                important: '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>',
+              };
+              
+              const title = type === 'note' ? 'Note' : type === 'tip' ? 'Tip' : type === 'warning' ? 'Warning' : type === 'important' ? 'Important' : 'Danger';
+              
+              titleHtml.content = `<div class="flex items-center gap-2 font-bold mb-2 uppercase tracking-wide text-sm alert-title">${icons[type] || icons.note} ${title}</div>`;
+              inline.children?.unshift(titleHtml);
+            }
+          }
+        }
+      }
+    });
+
+    // 3. OTHER STANDARD RENDERERS (Headings, Paragraphs, etc.)
+    instance.renderer.rules.heading_open = (tokens, idx) => {
+      const tag = tokens[idx].tag;
+      const title = tokens[idx + 1].content;
+      const id = slugify(title);
+      return `<${tag} id="${id}" class="md-heading md-${tag}">`;
+    };
+
+    instance.renderer.rules.heading_close = (tokens, idx) => {
+      const tag = tokens[idx].tag;
+      const id = slugify(tokens[idx - 1].content);
+      const link = `<a href="#${id}" class="md-heading-link">#</a>`;
+      return `${link}</${tag}>`;
+    };
+
+    instance.renderer.rules.paragraph_open = () => `<p class="md-p">`;
+    instance.renderer.rules.code_inline = (tokens, idx) => `<code class="md-code-inline">${instance.utils.escapeHtml(tokens[idx].content)}</code>`;
+    
+    // Standard Blockquote (if not a Callout)
+    instance.renderer.rules.blockquote_open = (tokens, idx, options, _env, self) => {
+      if (tokens[idx].attrGet('class')?.includes('gfm-alert')) {
+        return self.renderToken(tokens, idx, options);
+      }
+      return `<blockquote class="relative my-8 pl-8 pr-4 py-4 border-l-4 border-primary/40 bg-gray-50/50 dark:bg-gray-800/30 rounded-r-xl italic text-gray-700 dark:text-gray-300 shadow-sm ring-1 ring-inset ring-gray-200 dark:ring-gray-800"><svg class="absolute top-4 left-2 w-4 h-4 text-primary/40 transform -scale-x-100" fill="currentColor" viewBox="0 0 24 24"><path d="M14.017 21L14.017 18C14.017 16.8954 13.1216 16 12.017 16H9C8.44772 16 8 15.5523 8 15V9C8 8.44772 8.44772 8 9 8H15C15.5523 8 16 8.44772 16 9V11C16 11.5523 16.4477 12 17 12H20C20.5523 12 21 11.5523 21 11V7C21 4.79086 19.2091 3 17 3H7C4.79086 3 3 4.79086 3 7V15C3 17.2091 4.79086 19 7 19H14.017ZM21.983 21H16.983C16.4307 21 15.983 20.5523 15.983 20V16.983C15.983 16.4307 16.4307 15.983 16.983 15.983H19.983V14.983H18.983C18.4307 14.983 17.983 14.5353 17.983 13.983V10.983C17.983 10.4307 18.4307 9.983 18.983 9.983H21.983C22.5353 9.983 22.983 10.4307 22.983 10.983V13.983C22.983 14.5353 22.5353 14.983 21.983 14.983H20.983V20C20.983 20.5523 20.5353 21 21.983 21Z" /></svg>`;
+    };
+
+    instance.renderer.rules.table_open = () => `<div class="md-table-wrapper"><table class="md-table">`;
+    instance.renderer.rules.table_close = () => `</table></div>`;
+    instance.renderer.rules.th_open = () => `<th class="md-th">`;
+    instance.renderer.rules.td_open = () => `<td class="md-td">`;
+    instance.renderer.rules.bullet_list_open = () => `<ul class="md-ul">`;
+    instance.renderer.rules.ordered_list_open = () => `<ol class="md-ol">`;
+
+    return instance;
+  }, []);
+
+  const renderedParts = useMemo(() => {
+    // Convert Markdown to a full HTML string
+    const htmlString = md.render(content);
+
+    // Map HTML nodes cleanly to React Components
+    return parse(htmlString, {
+      replace: (domNode) => {
+        if (domNode instanceof Element && domNode.attribs) {
+          
+          // Swap Code Blocks
+          if (domNode.attribs["data-code-block"]) {
+            // Because domNode.children[0] comes from html-react-parser, it's already safely unescaped!
+            const rawCode = (domNode.children[0] as any)?.data || "";
+            return <CodeBlock language={domNode.attribs["data-language"]} code={rawCode} />;
+          }
+
+          // Swap Mermaid Blocks
+          if (domNode.attribs["data-mermaid-block"]) {
+            const rawCode = (domNode.children[0] as any)?.data || "";
+            return <MermaidBlock code={rawCode} />;
+          }
+        }
+      },
+    });
+  }, [content, md]);
+
+  return { renderedParts };
+}

--- a/debug/src/lib/api.ts
+++ b/debug/src/lib/api.ts
@@ -138,19 +138,38 @@ async function post<T>(path: string, body?: BodyInit | null, init?: RequestInit)
   return res.json();
 }
 
+async function readError(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (data?.detail) {
+      if (typeof data.detail === "string") return data.detail;
+      if (typeof data.detail === "object") {
+        return data.detail.message || data.detail.code || JSON.stringify(data.detail);
+      }
+    }
+    return JSON.stringify(data);
+  } catch {
+    try {
+      return await res.text();
+    } catch {
+      return `${res.status} ${res.statusText}`;
+    }
+  }
+}
+
 async function put<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(path, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(await readError(res));
   return res.json();
 }
 
 async function del<T>(path: string): Promise<T> {
   const res = await fetch(path, { method: "DELETE" });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(await readError(res));
   return res.json();
 }
 
@@ -185,13 +204,47 @@ export interface LLMEffective {
   source: "env" | "db";
 }
 
+export interface SecretStatus {
+  name: string;
+  env_var: string;
+  db_set: boolean;
+  env_set: boolean;
+  source: "db" | "env" | "unset";
+  masked: string | null;
+}
+
+export interface OAuthClientStatus {
+  provider: string;
+  client_id_masked: string | null;
+  client_secret_masked: string | null;
+  client_id_source: "db" | "env" | "unset";
+  client_secret_source: "db" | "env" | "unset";
+}
+
+export interface ComposioConfigPublic {
+  api_key_masked: string | null;
+  user_id: string | null;
+  api_key_source: "db" | "env" | "unset";
+  user_id_source: "db" | "env" | "unset";
+}
+
+export interface PyJIITPublic {
+  username: string | null;
+  password_masked: string | null;
+  configured: boolean;
+}
+
 export interface IntegrationsStatus {
   oauth: OAuthConnection[];
+  oauth_clients: OAuthClientStatus[];
   composio: ComposioStatus;
+  composio_config: ComposioConfigPublic;
   llm: {
     effective: LLMEffective;
     providers_configured: Record<string, boolean>;
+    secrets: SecretStatus[];
   };
+  pyjiit: PyJIITPublic;
   native_tools: Array<{ id: string; label: string; auth: string }>;
   agents: Array<{ id: string; label: string; module: string }>;
   infra: Record<string, { ok: boolean; error?: string }>;
@@ -279,4 +332,35 @@ export const api = {
     put<{ effective: LLMEffective }>(`${INTEGRATIONS_BASE}/llm/model`, payload),
   llmClear: () =>
     del<{ effective: LLMEffective }>(`${INTEGRATIONS_BASE}/llm/model`),
+
+  // Encrypted LLM provider keys
+  secretSet: (name: string, value: string) =>
+    put<{ status: string; name: string }>(`${INTEGRATIONS_BASE}/secrets/${name}`, { value }),
+  secretClear: (name: string) =>
+    del<{ status: string; name: string }>(`${INTEGRATIONS_BASE}/secrets/${name}`),
+
+  // OAuth client (client_id/client_secret)
+  oauthClientSet: (
+    provider: string,
+    payload: { client_id?: string; client_secret?: string },
+  ) =>
+    put<{ status: string; provider: string }>(
+      `${INTEGRATIONS_BASE}/oauth-clients/${provider}`,
+      payload,
+    ),
+  oauthClientClear: (provider: string) =>
+    del<{ status: string; provider: string }>(
+      `${INTEGRATIONS_BASE}/oauth-clients/${provider}`,
+    ),
+
+  // Composio config
+  composioConfigSet: (payload: { api_key?: string; user_id?: string }) =>
+    put<{ status: string }>(`${INTEGRATIONS_BASE}/composio-config`, payload),
+  composioConfigClear: () =>
+    del<{ status: string }>(`${INTEGRATIONS_BASE}/composio-config`),
+
+  // PyJIIT credentials
+  pyjiitSet: (payload: { username?: string; password?: string }) =>
+    put<{ status: string }>(`${INTEGRATIONS_BASE}/pyjiit`, payload),
+  pyjiitClear: () => del<{ status: string }>(`${INTEGRATIONS_BASE}/pyjiit`),
 };

--- a/debug/src/styles.css
+++ b/debug/src/styles.css
@@ -299,3 +299,142 @@ button:active {
   from { opacity: 0; transform: translate(-50%, -48%) scale(0.96); }
   to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 }
+
+/* ── Markdown Renderer Styles ── */
+.markdown-renderer {
+  font-family: var(--font-main);
+  -webkit-font-smoothing: antialiased;
+}
+
+.md-p {
+  margin-bottom: 0.75rem;
+  line-height: 1.6;
+}
+.md-p:last-child {
+  margin-bottom: 0;
+}
+
+.md-ul, .md-ol {
+  margin-top: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding-left: 1.25rem;
+}
+.md-ul { list-style-type: disc; }
+.md-ol { list-style-type: decimal; }
+
+.md-ul li, .md-ol li {
+  margin-bottom: 0.25rem;
+  padding-left: 0.25rem;
+}
+.md-ul li::marker, .md-ol li::marker {
+  color: var(--text-muted);
+}
+
+.md-heading {
+  color: var(--text-primary);
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.md-h1 { font-size: 1.5rem; border-bottom: 1px solid var(--border-color); padding-bottom: 0.5rem; }
+.md-h2 { font-size: 1.25rem; }
+.md-h3 { font-size: 1.125rem; }
+.md-h4 { font-size: 1rem; }
+
+.md-heading-link {
+  opacity: 0;
+  color: var(--text-muted);
+  text-decoration: none;
+  margin-left: 0.5rem;
+  transition: opacity 0.2s, color 0.2s;
+}
+.md-heading:hover .md-heading-link { opacity: 1; }
+.md-heading-link:hover { color: var(--accent-color); }
+
+.md-code-inline {
+  background: var(--input-bg);
+  border: 1px solid var(--border-color);
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--sky);
+}
+
+.md-table-wrapper {
+  margin: 1.5rem 0;
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+.md-table { width: 100%; border-collapse: collapse; }
+.md-th {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--input-bg);
+}
+.md-td {
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+.md-table tr:last-child .md-td { border-bottom: none; }
+
+/* Details / Summary */
+.markdown-renderer details {
+  margin: 1.5rem 0;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+.markdown-renderer summary {
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  outline: none;
+  transition: background 0.2s;
+}
+.markdown-renderer summary:hover { background: var(--input-bg); }
+.markdown-renderer details[open] summary {
+  border-bottom: 1px solid var(--border-color);
+  background: var(--input-bg);
+}
+.markdown-renderer details > *:not(summary) {
+  padding: 0 1rem;
+}
+.markdown-renderer details > p:first-of-type { margin-top: 1rem; }
+.markdown-renderer details > *:last-child { margin-bottom: 1rem; }
+
+/* GFM Alerts */
+.gfm-alert {
+  margin: 1.5rem 0;
+  border-left: 4px solid var(--border-color);
+  padding: 1rem 1.5rem;
+  border-radius: 0 8px 8px 0;
+  background: var(--input-bg);
+}
+.gfm-alert-note { border-left-color: #3b82f6; background: rgba(59, 130, 246, 0.1); }
+.gfm-alert-note .alert-title { color: #60a5fa; }
+
+.gfm-alert-tip { border-left-color: #22c55e; background: rgba(34, 197, 94, 0.1); }
+.gfm-alert-tip .alert-title { color: #4ade80; }
+
+.gfm-alert-important { border-left-color: #a855f7; background: rgba(168, 85, 247, 0.1); }
+.gfm-alert-important .alert-title { color: #c084fc; }
+
+.gfm-alert-warning { border-left-color: #eab308; background: rgba(234, 179, 8, 0.1); }
+.gfm-alert-warning .alert-title { color: #facc15; }
+
+.gfm-alert-danger, .gfm-alert-caution { border-left-color: #ef4444; background: rgba(239, 68, 68, 0.1); }
+.gfm-alert-danger .alert-title, .gfm-alert-caution .alert-title { color: #f87171; }

--- a/extension/entrypoints/sidepanel/AgentExecutor.tsx
+++ b/extension/entrypoints/sidepanel/AgentExecutor.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { wsClient } from "../utils/websocket-client";
 import { parseAgentCommand } from "../utils/parseAgentCommand";
+
 import { executeAgent, AgentStreamEvent } from "../utils/executeAgent";
 import { executeBrowserActions } from "../utils/executeActions";
 import { deleteServerSession, loadServerSessions, saveServerSessions } from "../utils/serverState";
@@ -37,6 +38,51 @@ import ReactMarkdown from "react-markdown";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
+
+function parseContent(raw: string): string {
+  if (!raw) return "";
+  const s = raw.trim();
+
+  const extractText = (obj: any): string[] => {
+    if (Array.isArray(obj)) return obj.flatMap(extractText);
+    if (obj && typeof obj === "object") {
+      if (obj.type === "text" && typeof obj.text === "string") return [obj.text];
+      if (typeof obj.text === "string" && Object.keys(obj).length <= 2) return [obj.text];
+    }
+    if (typeof obj === "string") return [obj];
+    return [];
+  };
+
+  try {
+    const parsed = JSON.parse(s);
+    if (typeof parsed === "object" && parsed !== null) {
+      const texts = extractText(parsed);
+      if (texts.length > 0) return texts.join("\n\n");
+    }
+    if (typeof parsed === "string") return parsed;
+  } catch (_) { /* continue */ }
+
+  if (s.startsWith("[{") || s.startsWith("{'")) {
+    try {
+      const jsonified = s.replace(/'/g, '"').replace(/"s\b/g, "'s").replace(/\\n/g, "\n");
+      const parsed = JSON.parse(jsonified);
+      const texts = extractText(parsed);
+      if (texts.length > 0) return texts.join("\n\n");
+    } catch (_) { /* continue */ }
+  }
+
+  const textBlockPattern = /["']text["']\s*:\s*["']((?:[^"'\\]|\\.)*)["']/g;
+  const matches: string[] = [];
+  let m;
+  while ((m = textBlockPattern.exec(s)) !== null) {
+    const decoded = m[1].replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, '"').replace(/\\'/g, "'").replace(/\\\\/g, "\\");
+    if (decoded.length > 10) matches.push(decoded);
+  }
+  if (matches.length > 0) return matches.join("\n\n");
+
+  return raw;
+}
+
 interface AgentExecutorProps {
 	wsConnected: boolean;
 }
@@ -1316,7 +1362,7 @@ export function AgentExecutor({ wsConnected }: AgentExecutorProps) {
 														code: ({ children }) => <code className="inline-code">{children}</code>,
 													}}
 												>
-													{msg.content}
+													{parseContent(msg.content)}
 												</ReactMarkdown>
 											</div>
 										</div>
@@ -1366,7 +1412,7 @@ export function AgentExecutor({ wsConnected }: AgentExecutorProps) {
 												),
 											}}
 										>
-											{msg.content}
+											{parseContent(msg.content)}
 										</ReactMarkdown>
 									)}
 								</div>

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ async def lifespan(app: FastAPI):
     try:
         await init_db()
         logger.info("Postgres: ready")
+
     except Exception as exc:
         logger.warning("Postgres init skipped: %s", exc)
 
@@ -54,6 +55,7 @@ async def lifespan(app: FastAPI):
         await neo4j.connect()
         await neo4j.create_constraints()
         logger.info("Neo4j: connected")
+
     except Exception as exc:
         logger.warning("Neo4j init skipped: %s", exc)
 
@@ -62,17 +64,38 @@ async def lifespan(app: FastAPI):
         os_client.connect()
         os_client.ensure_indices()
         logger.info("OpenSearch: connected, indices ready")
+
     except Exception as exc:
         logger.warning("OpenSearch init skipped: %s", exc)
 
     try:
+        from core.llm import reload_default_llm
+
+        await reload_default_llm()
+        logger.info("Default LLM resolved (DB override applied if present)")
+
+    except Exception as exc:
+        logger.warning("LLM default resolution skipped: %s", exc)
+
+    try:
         from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
         from memory.maintenance.consolidation import ConsolidationRunner
 
         runner = ConsolidationRunner()
         scheduler = AsyncIOScheduler()
-        scheduler.add_job(runner.hourly, "interval", hours=1, id="memory_hourly")
-        scheduler.add_job(runner.nightly, "cron", hour=3, id="memory_nightly")
+        scheduler.add_job(
+            runner.hourly,
+            "interval",
+            hours=1,
+            id="memory_hourly",
+        )
+        scheduler.add_job(
+            runner.nightly,
+            "cron",
+            hour=3,
+            id="memory_nightly",
+        )
         scheduler.add_job(
             runner.weekly,
             "cron",
@@ -83,6 +106,7 @@ async def lifespan(app: FastAPI):
         scheduler.start()
         app.state.scheduler = scheduler
         logger.info("Memory maintenance scheduler started")
+
     except Exception as exc:
         logger.warning("Scheduler init skipped: %s", exc)
 
@@ -93,11 +117,14 @@ async def lifespan(app: FastAPI):
     try:
         neo4j = get_neo4j()
         await neo4j.close()
+
     except Exception:
         pass
+
     try:
         os_client = get_opensearch()
         os_client.close()
+
     except Exception:
         pass
 
@@ -112,19 +139,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+from memory.api.router import router as memory_router  # noqa: E402
 from routers import (  # noqa: E402
     auth_router,
     automation_router,
-    browser_use_router as agent_router,
     calendar_router,
     conversations_router,
     debug_router,
-    integrations_router,
     file_upload_router,
     github_router,
     gmail_router,
     google_search_router,
     health_router,
+    integrations_router,
     pyjiit_router,
     react_agent_router,
     skills_router,
@@ -134,7 +161,9 @@ from routers import (  # noqa: E402
     website_validator_router,
     youtube_router,
 )
-from memory.api.router import router as memory_router  # noqa: E402
+from routers import (
+    browser_use_router as agent_router,
+)
 
 app.include_router(health_router, prefix="/api/genai/health")
 app.include_router(github_router, prefix="/api/genai/github")
@@ -162,11 +191,23 @@ app.mount("/mcp", MCPStreamableHTTPApp())
 
 @app.get("/")
 def root():
-    return {"name": app.title, "version": app.version}
+    return {
+        "name": app.title,
+        "version": app.version,
+    }
 
 
-def run(host: str = "0.0.0.0", port: int = 5454, reload: bool = True):
-    uvicorn.run("main:app", host=host, port=port, reload=reload)
+def run(
+    host: str = "0.0.0.0",
+    port: int = 5454,
+    reload: bool = True,
+):
+    uvicorn.run(
+        "main:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
 
 
 if __name__ == "__main__":

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,12 +1,30 @@
-from fastapi import APIRouter, HTTPException
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
+from core import get_logger
 from services.auth_service import AuthService
 from services.oauth_credentials_service import get_oauth_credentials_service
+from services.secrets_service import get_secrets_service
 
 router = APIRouter()
+logger = get_logger(__name__)
 auth_service = AuthService()
 creds = get_oauth_credentials_service()
+
+GOOGLE_SCOPES = [
+    "openid",
+    "email",
+    "profile",
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/youtube.readonly",
+]
+GITHUB_SCOPES = ["read:user", "user:email", "repo"]
+DASHBOARD_SETTINGS = "/settings"
 
 
 class GoogleExchangeRequest(BaseModel):
@@ -91,3 +109,72 @@ async def disconnect(provider: str):
 @router.get("/health")
 async def health():
     return {"status": "ok", "message": "Auth service running"}
+
+
+# ── Web-initiated OAuth flow (for the debug dashboard) ────────────────────────
+
+def _redirect_uri(request: Request, provider: str) -> str:
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/api/auth/{provider}/callback"
+
+
+@router.get("/google/start")
+async def google_start(request: Request):
+    sec = get_secrets_service()
+    client = await sec.get_oauth_client("google")
+    client_id = client.get("client_id")
+    if not client_id:
+        raise HTTPException(status_code=400, detail="google client_id not configured")
+    params = {
+        "client_id": client_id,
+        "redirect_uri": _redirect_uri(request, "google"),
+        "response_type": "code",
+        "scope": " ".join(GOOGLE_SCOPES),
+        "access_type": "offline",
+        "prompt": "consent",
+        "include_granted_scopes": "true",
+    }
+    return RedirectResponse(url=f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}")
+
+
+@router.get("/google/callback")
+async def google_callback(request: Request, code: str | None = None, error: str | None = None):
+    if error or not code:
+        return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_error={error or 'missing_code'}")
+    try:
+        result = await auth_service.exchange_google_code(code, _redirect_uri(request, "google"))
+        if "error" in result:
+            return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_error=exchange_failed")
+    except Exception:
+        logger.exception("Google OAuth callback failed")
+        return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_error=exception")
+    return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_connected=google")
+
+
+@router.get("/github/start")
+async def github_start(request: Request):
+    sec = get_secrets_service()
+    client = await sec.get_oauth_client("github")
+    client_id = client.get("client_id")
+    if not client_id:
+        raise HTTPException(status_code=400, detail="github client_id not configured")
+    params = {
+        "client_id": client_id,
+        "redirect_uri": _redirect_uri(request, "github"),
+        "scope": " ".join(GITHUB_SCOPES),
+    }
+    return RedirectResponse(url=f"https://github.com/login/oauth/authorize?{urlencode(params)}")
+
+
+@router.get("/github/callback")
+async def github_callback(code: str | None = None, error: str | None = None):
+    if error or not code:
+        return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_error={error or 'missing_code'}")
+    try:
+        result = await auth_service.exchange_github_code(code)
+        if "error" in result:
+            return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_error=exchange_failed")
+    except Exception:
+        logger.exception("GitHub OAuth callback failed")
+        return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_error=exception")
+    return RedirectResponse(url=f"{DASHBOARD_SETTINGS}?oauth_connected=github")

--- a/routers/debug.py
+++ b/routers/debug.py
@@ -202,7 +202,7 @@ async def get_run(run_id: str):
                 "name": s.name,
                 "task": s.task,
                 "status": s.status,
-                "result": (s.result or "")[:300] if s.result else None,
+                "result": s.result,
                 "started_at": s.started_at.isoformat(),
                 "completed_at": s.completed_at.isoformat() if s.completed_at else None,
             }

--- a/routers/integrations.py
+++ b/routers/integrations.py
@@ -18,19 +18,59 @@ logger = get_logger(__name__)
 LLM_SETTING_KEY = "llm.default"
 
 NATIVE_TOOLS = [
-    {"id": "pyjiit", "label": "PyJIIT", "auth": "username/password (per-request)"},
-    {"id": "skills", "label": "Skills", "auth": "none (local)"},
-    {"id": "voice", "label": "Voice (Whisper)", "auth": "none (local)"},
-    {"id": "browser-use", "label": "Browser-use", "auth": "none (extension)"},
-    {"id": "website", "label": "Website scraper", "auth": "none"},
-    {"id": "google-search", "label": "Google Search", "auth": "API key (server)"},
-    {"id": "github-crawler", "label": "GitHub Crawler", "auth": "public web"},
+    {
+        "id": "pyjiit",
+        "label": "PyJIIT",
+        "auth": "username/password (per-request)",
+    },
+    {
+        "id": "skills",
+        "label": "Skills",
+        "auth": "none (local)",
+    },
+    {
+        "id": "voice",
+        "label": "Voice (Whisper)",
+        "auth": "none (local)",
+    },
+    {
+        "id": "browser-use",
+        "label": "Browser-use",
+        "auth": "none (extension)",
+    },
+    {
+        "id": "website",
+        "label": "Website scraper",
+        "auth": "none",
+    },
+    {
+        "id": "google-search",
+        "label": "Google Search",
+        "auth": "API key (server)",
+    },
+    {
+        "id": "github-crawler",
+        "label": "GitHub Crawler",
+        "auth": "public web",
+    },
 ]
 
 REGISTERED_AGENTS = [
-    {"id": "react_agent", "label": "ReAct Agent", "module": "agents.react_agent"},
-    {"id": "while_loop_harness", "label": "While-Loop Harness", "module": "agents.while_loop_harness"},
-    {"id": "browser_use", "label": "Browser-Use Agent", "module": "services.browser_use_service"},
+    {
+        "id": "react_agent",
+        "label": "ReAct Agent",
+        "module": "agents.react_agent",
+    },
+    {
+        "id": "while_loop_harness",
+        "label": "While-Loop Harness",
+        "module": "agents.while_loop_harness",
+    },
+    {
+        "id": "browser_use",
+        "label": "Browser-Use Agent",
+        "module": "services.browser_use_service",
+    },
 ]
 
 
@@ -58,10 +98,18 @@ async def _llm_env_status() -> dict[str, bool]:
 
 
 def _llm_default_from_env() -> dict[str, Any]:
+    """Resolve provider/model/temperature from settings; fall back to the
+    provider's default_model when the user didn't pin one in env."""
+    from core.llm import PROVIDER_CONFIGS
+
+    s = get_settings()
+    provider = (s.default_llm_provider or "google").lower()
+    cfg = PROVIDER_CONFIGS.get(provider) or PROVIDER_CONFIGS["google"]
+    model = s.default_llm_model or cfg.get("default_model") or ""
     return {
-        "provider": "google",
-        "model": "gemini-2.5-flash",
-        "temperature": 0.4,
+        "provider": provider,
+        "model": model,
+        "temperature": s.default_llm_temperature,
         "source": "env",
     }
 
@@ -71,12 +119,17 @@ async def _llm_effective() -> dict[str, Any]:
     override = await state.get_setting(LLM_SETTING_KEY)
     base = _llm_default_from_env()
     if override:
-        return {**base, **override, "source": "db"}
+        return {
+            **base,
+            **override,
+            "source": "db",
+        }
     return base
 
 
 async def _composio_client():
     from services.secrets_service import get_secrets_service
+
     cfg = await get_secrets_service().get_composio()
     api_key = cfg.get("api_key")
     user_id = cfg.get("user_id") or None
@@ -96,45 +149,75 @@ async def _composio_status() -> dict[str, Any]:
     connected: list[dict[str, Any]] = []
     error: str | None = None
     try:
-        accounts = client.connected_accounts.list(user_ids=[user_id]) if user_id else client.connected_accounts.list()
+        accounts = (
+            client.connected_accounts.list(user_ids=[user_id])
+            if user_id
+            else client.connected_accounts.list()
+        )
         items = getattr(accounts, "items", None) or accounts or []
         for acc in items:
-            connected.append({
-                "id": getattr(acc, "id", None),
-                "toolkit": getattr(acc, "toolkit_slug", None) or getattr(acc, "toolkit", None),
-                "status": getattr(acc, "status", None),
-                "user_id": getattr(acc, "user_id", None),
-            })
+            connected.append(
+                {
+                    "id": getattr(acc, "id", None),
+                    "toolkit": getattr(acc, "toolkit_slug", None)
+                    or getattr(acc, "toolkit", None),
+                    "status": getattr(acc, "status", None),
+                    "user_id": getattr(acc, "user_id", None),
+                }
+            )
     except Exception as exc:
         logger.exception("Composio connected_accounts.list failed")
         error = str(exc)
-    return {"configured": True, "user_id": user_id, "connected": connected, "error": error}
+    return {
+        "configured": True,
+        "user_id": user_id,
+        "connected": connected,
+        "error": error,
+    }
 
 
 async def _infra_status() -> dict[str, Any]:
     out: dict[str, Any] = {}
     # Postgres
     try:
+        from sqlalchemy import text
+
         from core.db import engine
+
         async with engine.connect() as c:
-            await c.execute_options(no_parameters=True)
+            await c.execute(text("SELECT 1"))
         out["postgres"] = {"ok": True}
     except Exception as exc:
-        out["postgres"] = {"ok": False, "error": str(exc)}
+        out["postgres"] = {
+            "ok": False,
+            "error": str(exc),
+        }
     # Neo4j
     try:
         from core.clients.neo4j import get_neo4j
+
         n = get_neo4j()
-        out["neo4j"] = {"ok": bool(getattr(n, "_driver", None))}
+        out["neo4j"] = {
+            "ok": bool(getattr(n, "_driver", None)),
+        }
     except Exception as exc:
-        out["neo4j"] = {"ok": False, "error": str(exc)}
+        out["neo4j"] = {
+            "ok": False,
+            "error": str(exc),
+        }
     # OpenSearch
     try:
         from core.clients.opensearch import get_opensearch
+
         c = get_opensearch()
-        out["opensearch"] = {"ok": bool(getattr(c, "_client", None))}
+        out["opensearch"] = {
+            "ok": bool(getattr(c, "_client", None)),
+        }
     except Exception as exc:
-        out["opensearch"] = {"ok": False, "error": str(exc)}
+        out["opensearch"] = {
+            "ok": False,
+            "error": str(exc),
+        }
     return out
 
 
@@ -161,15 +244,26 @@ async def status():
 
 @router.get("/oauth")
 async def oauth_list():
-    return {"connections": await get_oauth_credentials_service().list_all()}
+    return {
+        "connections": await get_oauth_credentials_service().list_all(),
+    }
 
 
 @router.delete("/oauth/{provider}")
 async def oauth_disconnect(provider: str):
     ok = await get_oauth_credentials_service().delete(provider)
     if not ok:
-        raise HTTPException(status_code=404, detail={"code": "not_connected", "provider": provider})
-    return {"status": "disconnected", "provider": provider}
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "not_connected",
+                "provider": provider,
+            },
+        )
+    return {
+        "status": "disconnected",
+        "provider": provider,
+    }
 
 
 @router.get("/composio")
@@ -181,13 +275,30 @@ async def composio_list():
 async def composio_connect(toolkit: str):
     client, user_id = await _composio_client()
     if client is None:
-        raise HTTPException(status_code=400, detail={"code": "composio_not_configured"})
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "composio_not_configured",
+            },
+        )
     if not user_id:
-        raise HTTPException(status_code=400, detail={"code": "composio_user_id_missing"})
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "composio_user_id_missing",
+            },
+        )
     try:
         result = client.toolkits.authorize(user_id=user_id, toolkit=toolkit)
-        redirect_url = getattr(result, "redirect_url", None) or getattr(result, "url", None) or str(result)
-        return {"toolkit": toolkit, "redirect_url": redirect_url}
+        redirect_url = (
+            getattr(result, "redirect_url", None)
+            or getattr(result, "url", None)
+            or str(result)
+        )
+        return {
+            "toolkit": toolkit,
+            "redirect_url": redirect_url,
+        }
     except Exception as exc:
         logger.exception("Composio toolkits.authorize failed")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -197,13 +308,24 @@ async def composio_connect(toolkit: str):
 async def composio_disconnect(connected_account_id: str):
     client, _ = await _composio_client()
     if client is None:
-        raise HTTPException(status_code=400, detail={"code": "composio_not_configured"})
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "composio_not_configured",
+            },
+        )
     try:
         client.connected_accounts.delete(connected_account_id)
-        return {"status": "disconnected", "id": connected_account_id}
+        return {
+            "status": "disconnected",
+            "id": connected_account_id,
+        }
     except Exception as exc:
         logger.exception("Composio connected_accounts.delete failed")
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise HTTPException(
+            status_code=500,
+            detail=str(exc),
+        )
 
 
 @router.get("/llm/model")
@@ -218,7 +340,10 @@ async def llm_get():
 @router.put("/llm/model")
 async def llm_set(payload: LLMOverride):
     if not payload.provider and not payload.model and payload.temperature is None:
-        raise HTTPException(status_code=400, detail="At least one of provider/model/temperature is required")
+        raise HTTPException(
+            status_code=400,
+            detail="At least one of provider/model/temperature is required",
+        )
     value = {k: v for k, v in payload.model_dump().items() if v is not None}
     state = AppStateService()
     existing = await state.get_setting(LLM_SETTING_KEY) or {}
@@ -226,10 +351,13 @@ async def llm_set(payload: LLMOverride):
     await state.set_setting(LLM_SETTING_KEY, merged)
     try:
         from core.llm import reload_default_llm
+
         await reload_default_llm()
     except Exception:
         logger.exception("Failed to reload default LLM after override")
-    return {"effective": await _llm_effective()}
+    return {
+        "effective": await _llm_effective(),
+    }
 
 
 @router.delete("/llm/model")
@@ -238,10 +366,13 @@ async def llm_clear():
     await state.delete_setting(LLM_SETTING_KEY)
     try:
         from core.llm import reload_default_llm
+
         await reload_default_llm()
     except Exception:
         logger.exception("Failed to reload default LLM after clear")
-    return {"effective": await _llm_effective()}
+    return {
+        "effective": await _llm_effective(),
+    }
 
 
 @router.get("/llm/providers")
@@ -251,12 +382,16 @@ async def llm_providers():
 
 @router.get("/agents")
 async def agents_list():
-    return {"agents": REGISTERED_AGENTS}
+    return {
+        "agents": REGISTERED_AGENTS,
+    }
 
 
 @router.get("/native")
 async def native_tools_list():
-    return {"tools": NATIVE_TOOLS}
+    return {
+        "tools": NATIVE_TOOLS,
+    }
 
 
 @router.get("/infra")
@@ -265,6 +400,7 @@ async def infra():
 
 
 # ── Editable secrets (LLM provider keys, ollama base url) ─────────────────────
+
 
 class SecretValue(BaseModel):
     value: str
@@ -278,33 +414,50 @@ async def secrets_list():
 @router.put("/secrets/{name}")
 async def secrets_set(name: str, payload: SecretValue):
     if name not in SECRET_REGISTRY:
-        raise HTTPException(status_code=404, detail={"code": "unknown_secret", "name": name})
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_secret", "name": name}
+        )
     if not payload.value:
         raise HTTPException(status_code=400, detail="value is required")
     await get_secrets_service().set(name, payload.value)
     # Reload default LLM in case the active provider key changed.
     try:
         from core.llm import reload_default_llm
+
         await reload_default_llm()
     except Exception:
         logger.exception("Failed to reload default LLM after secret change")
-    return {"status": "ok", "name": name}
+    return {
+        "status": "ok",
+        "name": name,
+    }
 
 
 @router.delete("/secrets/{name}")
 async def secrets_clear(name: str):
     if name not in SECRET_REGISTRY:
-        raise HTTPException(status_code=404, detail={"code": "unknown_secret", "name": name})
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "unknown_secret",
+                "name": name,
+            },
+        )
     await get_secrets_service().clear(name)
     try:
         from core.llm import reload_default_llm
+
         await reload_default_llm()
     except Exception:
         logger.exception("Failed to reload default LLM after secret clear")
-    return {"status": "ok", "name": name}
+    return {
+        "status": "ok",
+        "name": name,
+    }
 
 
 # ── OAuth client (client_id / client_secret) ──────────────────────────────────
+
 
 class OAuthClientPayload(BaseModel):
     client_id: Optional[str] = None
@@ -319,26 +472,39 @@ async def oauth_clients_list():
 @router.put("/oauth-clients/{provider}")
 async def oauth_clients_set(provider: str, payload: OAuthClientPayload):
     if provider not in {"google", "github"}:
-        raise HTTPException(status_code=404, detail={"code": "unknown_provider", "provider": provider})
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_provider", "provider": provider}
+        )
     if payload.client_id is None and payload.client_secret is None:
-        raise HTTPException(status_code=400, detail="client_id and/or client_secret required")
+        raise HTTPException(
+            status_code=400, detail="client_id and/or client_secret required"
+        )
     await get_secrets_service().set_oauth_client(
         provider,
         client_id=payload.client_id,
         client_secret=payload.client_secret,
     )
-    return {"status": "ok", "provider": provider}
+    return {
+        "status": "ok",
+        "provider": provider,
+    }
 
 
 @router.delete("/oauth-clients/{provider}")
 async def oauth_clients_clear(provider: str):
     if provider not in {"google", "github"}:
-        raise HTTPException(status_code=404, detail={"code": "unknown_provider", "provider": provider})
+        raise HTTPException(
+            status_code=404, detail={"code": "unknown_provider", "provider": provider}
+        )
     await get_secrets_service().clear_oauth_client(provider)
-    return {"status": "ok", "provider": provider}
+    return {
+        "status": "ok",
+        "provider": provider,
+    }
 
 
 # ── Composio config ───────────────────────────────────────────────────────────
+
 
 class ComposioConfigPayload(BaseModel):
     api_key: Optional[str] = None
@@ -354,7 +520,9 @@ async def composio_config_get():
 async def composio_config_set(payload: ComposioConfigPayload):
     if payload.api_key is None and payload.user_id is None:
         raise HTTPException(status_code=400, detail="api_key and/or user_id required")
-    await get_secrets_service().set_composio(api_key=payload.api_key, user_id=payload.user_id)
+    await get_secrets_service().set_composio(
+        api_key=payload.api_key, user_id=payload.user_id
+    )
     return {"status": "ok"}
 
 
@@ -365,6 +533,7 @@ async def composio_config_clear():
 
 
 # ── PyJIIT credentials ────────────────────────────────────────────────────────
+
 
 class PyJIITPayload(BaseModel):
     username: Optional[str] = None
@@ -380,11 +549,17 @@ async def pyjiit_get():
 async def pyjiit_set(payload: PyJIITPayload):
     if payload.username is None and payload.password is None:
         raise HTTPException(status_code=400, detail="username and/or password required")
-    await get_secrets_service().set_pyjiit(username=payload.username, password=payload.password)
-    return {"status": "ok"}
+    await get_secrets_service().set_pyjiit(
+        username=payload.username, password=payload.password
+    )
+    return {
+        "status": "ok",
+    }
 
 
 @router.delete("/pyjiit")
 async def pyjiit_clear():
     await get_secrets_service().clear_pyjiit()
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+    }

--- a/routers/integrations.py
+++ b/routers/integrations.py
@@ -7,8 +7,10 @@ from pydantic import BaseModel
 
 from core import get_logger
 from core.config import get_settings
+from core.crypto import CryptoNotConfigured
 from services.app_state import AppStateService
 from services.oauth_credentials_service import get_oauth_credentials_service
+from services.secrets_service import SECRET_REGISTRY, get_secrets_service
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -38,17 +40,21 @@ class LLMOverride(BaseModel):
     temperature: Optional[float] = None
 
 
-def _llm_env_status() -> dict[str, bool]:
-    s = get_settings()
-    return {
-        "google": bool(s.google_api_key),
-        "openai": bool(s.openai_api_key),
-        "anthropic": bool(s.anthropic_api_key),
-        "deepseek": bool(s.deepseek_api_key),
-        "openrouter": bool(s.openrouter_api_key),
-        "ollama": bool(s.ollama_base_url),
-        "tavily": bool(s.tavily_api_key),
-    }
+async def _llm_env_status() -> dict[str, bool]:
+    """Provider configured if either env or DB secret has a value."""
+    sec = get_secrets_service()
+    out: dict[str, bool] = {}
+    for provider, secret_name in (
+        ("google", "google_api_key"),
+        ("openai", "openai_api_key"),
+        ("anthropic", "anthropic_api_key"),
+        ("deepseek", "deepseek_api_key"),
+        ("openrouter", "openrouter_api_key"),
+        ("ollama", "ollama_base_url"),
+        ("tavily", "tavily_api_key"),
+    ):
+        out[provider] = bool(await sec.resolve(secret_name))
+    return out
 
 
 def _llm_default_from_env() -> dict[str, Any]:
@@ -69,19 +75,22 @@ async def _llm_effective() -> dict[str, Any]:
     return base
 
 
-def _composio_client():
-    s = get_settings()
-    if not s.composio_api_key:
+async def _composio_client():
+    from services.secrets_service import get_secrets_service
+    cfg = await get_secrets_service().get_composio()
+    api_key = cfg.get("api_key")
+    user_id = cfg.get("user_id") or None
+    if not api_key:
         return None, None
     try:
         from composio import Composio
     except ImportError:
         return None, None
-    return Composio(api_key=s.composio_api_key), s.composio_user_id
+    return Composio(api_key=api_key), user_id
 
 
 async def _composio_status() -> dict[str, Any]:
-    client, user_id = _composio_client()
+    client, user_id = await _composio_client()
     if client is None:
         return {"configured": False, "user_id": None, "connected": [], "error": None}
     connected: list[dict[str, Any]] = []
@@ -132,13 +141,18 @@ async def _infra_status() -> dict[str, Any]:
 @router.get("/status")
 async def status():
     creds = get_oauth_credentials_service()
+    sec = get_secrets_service()
     return {
         "oauth": await creds.list_all(),
+        "oauth_clients": await sec.list_oauth_clients(),
         "composio": await _composio_status(),
+        "composio_config": await sec.composio_public(),
         "llm": {
             "effective": await _llm_effective(),
-            "providers_configured": _llm_env_status(),
+            "providers_configured": await _llm_env_status(),
+            "secrets": await sec.list_status(),
         },
+        "pyjiit": await sec.pyjiit_public(),
         "native_tools": NATIVE_TOOLS,
         "agents": REGISTERED_AGENTS,
         "infra": await _infra_status(),
@@ -165,7 +179,7 @@ async def composio_list():
 
 @router.post("/composio/connect/{toolkit}")
 async def composio_connect(toolkit: str):
-    client, user_id = _composio_client()
+    client, user_id = await _composio_client()
     if client is None:
         raise HTTPException(status_code=400, detail={"code": "composio_not_configured"})
     if not user_id:
@@ -181,7 +195,7 @@ async def composio_connect(toolkit: str):
 
 @router.delete("/composio/{connected_account_id}")
 async def composio_disconnect(connected_account_id: str):
-    client, _ = _composio_client()
+    client, _ = await _composio_client()
     if client is None:
         raise HTTPException(status_code=400, detail={"code": "composio_not_configured"})
     try:
@@ -196,7 +210,7 @@ async def composio_disconnect(connected_account_id: str):
 async def llm_get():
     return {
         "effective": await _llm_effective(),
-        "providers_configured": _llm_env_status(),
+        "providers_configured": await _llm_env_status(),
         "env_default": _llm_default_from_env(),
     }
 
@@ -210,6 +224,11 @@ async def llm_set(payload: LLMOverride):
     existing = await state.get_setting(LLM_SETTING_KEY) or {}
     merged = {**existing, **value}
     await state.set_setting(LLM_SETTING_KEY, merged)
+    try:
+        from core.llm import reload_default_llm
+        await reload_default_llm()
+    except Exception:
+        logger.exception("Failed to reload default LLM after override")
     return {"effective": await _llm_effective()}
 
 
@@ -217,12 +236,17 @@ async def llm_set(payload: LLMOverride):
 async def llm_clear():
     state = AppStateService()
     await state.delete_setting(LLM_SETTING_KEY)
+    try:
+        from core.llm import reload_default_llm
+        await reload_default_llm()
+    except Exception:
+        logger.exception("Failed to reload default LLM after clear")
     return {"effective": await _llm_effective()}
 
 
 @router.get("/llm/providers")
 async def llm_providers():
-    return _llm_env_status()
+    return await _llm_env_status()
 
 
 @router.get("/agents")
@@ -238,3 +262,129 @@ async def native_tools_list():
 @router.get("/infra")
 async def infra():
     return await _infra_status()
+
+
+# ── Editable secrets (LLM provider keys, ollama base url) ─────────────────────
+
+class SecretValue(BaseModel):
+    value: str
+
+
+@router.get("/secrets")
+async def secrets_list():
+    return {"secrets": await get_secrets_service().list_status()}
+
+
+@router.put("/secrets/{name}")
+async def secrets_set(name: str, payload: SecretValue):
+    if name not in SECRET_REGISTRY:
+        raise HTTPException(status_code=404, detail={"code": "unknown_secret", "name": name})
+    if not payload.value:
+        raise HTTPException(status_code=400, detail="value is required")
+    await get_secrets_service().set(name, payload.value)
+    # Reload default LLM in case the active provider key changed.
+    try:
+        from core.llm import reload_default_llm
+        await reload_default_llm()
+    except Exception:
+        logger.exception("Failed to reload default LLM after secret change")
+    return {"status": "ok", "name": name}
+
+
+@router.delete("/secrets/{name}")
+async def secrets_clear(name: str):
+    if name not in SECRET_REGISTRY:
+        raise HTTPException(status_code=404, detail={"code": "unknown_secret", "name": name})
+    await get_secrets_service().clear(name)
+    try:
+        from core.llm import reload_default_llm
+        await reload_default_llm()
+    except Exception:
+        logger.exception("Failed to reload default LLM after secret clear")
+    return {"status": "ok", "name": name}
+
+
+# ── OAuth client (client_id / client_secret) ──────────────────────────────────
+
+class OAuthClientPayload(BaseModel):
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+
+
+@router.get("/oauth-clients")
+async def oauth_clients_list():
+    return {"clients": await get_secrets_service().list_oauth_clients()}
+
+
+@router.put("/oauth-clients/{provider}")
+async def oauth_clients_set(provider: str, payload: OAuthClientPayload):
+    if provider not in {"google", "github"}:
+        raise HTTPException(status_code=404, detail={"code": "unknown_provider", "provider": provider})
+    if payload.client_id is None and payload.client_secret is None:
+        raise HTTPException(status_code=400, detail="client_id and/or client_secret required")
+    await get_secrets_service().set_oauth_client(
+        provider,
+        client_id=payload.client_id,
+        client_secret=payload.client_secret,
+    )
+    return {"status": "ok", "provider": provider}
+
+
+@router.delete("/oauth-clients/{provider}")
+async def oauth_clients_clear(provider: str):
+    if provider not in {"google", "github"}:
+        raise HTTPException(status_code=404, detail={"code": "unknown_provider", "provider": provider})
+    await get_secrets_service().clear_oauth_client(provider)
+    return {"status": "ok", "provider": provider}
+
+
+# ── Composio config ───────────────────────────────────────────────────────────
+
+class ComposioConfigPayload(BaseModel):
+    api_key: Optional[str] = None
+    user_id: Optional[str] = None
+
+
+@router.get("/composio-config")
+async def composio_config_get():
+    return await get_secrets_service().composio_public()
+
+
+@router.put("/composio-config")
+async def composio_config_set(payload: ComposioConfigPayload):
+    if payload.api_key is None and payload.user_id is None:
+        raise HTTPException(status_code=400, detail="api_key and/or user_id required")
+    await get_secrets_service().set_composio(api_key=payload.api_key, user_id=payload.user_id)
+    return {"status": "ok"}
+
+
+@router.delete("/composio-config")
+async def composio_config_clear():
+    await get_secrets_service().clear_composio()
+    return {"status": "ok"}
+
+
+# ── PyJIIT credentials ────────────────────────────────────────────────────────
+
+class PyJIITPayload(BaseModel):
+    username: Optional[str] = None
+    password: Optional[str] = None
+
+
+@router.get("/pyjiit")
+async def pyjiit_get():
+    return await get_secrets_service().pyjiit_public()
+
+
+@router.put("/pyjiit")
+async def pyjiit_set(payload: PyJIITPayload):
+    if payload.username is None and payload.password is None:
+        raise HTTPException(status_code=400, detail="username and/or password required")
+    await get_secrets_service().set_pyjiit(username=payload.username, password=payload.password)
+    return {"status": "ok"}
+
+
+@router.delete("/pyjiit")
+async def pyjiit_clear():
+    await get_secrets_service().clear_pyjiit()
+    return {"status": "ok"}

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 
 import requests
 from dotenv import load_dotenv
 
 from core import get_logger
-from core.config import get_settings
 from services.oauth_credentials_service import get_oauth_credentials_service
 
 load_dotenv()
@@ -16,23 +14,29 @@ logger = get_logger(__name__)
 
 class AuthService:
     def __init__(self):
-        settings = get_settings()
-        self.google_client_id = settings.google_oauth_client_id
-        self.google_client_secret = settings.google_client_secret or os.environ.get("GOOGLE_CLIENT_SECRET", "")
-        self.github_client_id = settings.github_client_id or os.environ.get("GITHUB_CLIENT_ID", "")
-        self.github_client_secret = settings.github_client_secret or os.environ.get("GITHUB_CLIENT_SECRET", "")
         self.creds = get_oauth_credentials_service()
 
+    async def _google_creds(self) -> tuple[str, str]:
+        from services.secrets_service import get_secrets_service
+        c = await get_secrets_service().get_oauth_client("google")
+        return c.get("client_id", ""), c.get("client_secret", "")
+
+    async def _github_creds(self) -> tuple[str, str]:
+        from services.secrets_service import get_secrets_service
+        c = await get_secrets_service().get_oauth_client("github")
+        return c.get("client_id", ""), c.get("client_secret", "")
+
     async def exchange_google_code(self, code: str, redirect_uri: str) -> Dict[str, Any]:
-        if not self.google_client_secret:
+        google_client_id, google_client_secret = await self._google_creds()
+        if not google_client_secret:
             raise ValueError("GOOGLE_CLIENT_SECRET is not configured")
 
         resp = requests.post(
             "https://oauth2.googleapis.com/token",
             data={
                 "code": code,
-                "client_id": self.google_client_id,
-                "client_secret": self.google_client_secret,
+                "client_id": google_client_id,
+                "client_secret": google_client_secret,
                 "redirect_uri": redirect_uri,
                 "grant_type": "authorization_code",
             },
@@ -84,15 +88,16 @@ class AuthService:
 
     async def refresh_google_token(self, refresh_token: str) -> Dict[str, Any]:
         # Legacy endpoint — kept for back-compat during migration. New flow refreshes server-side.
-        if not self.google_client_secret:
+        google_client_id, google_client_secret = await self._google_creds()
+        if not google_client_secret:
             raise ValueError("GOOGLE_CLIENT_SECRET is not configured")
 
         response = requests.post(
             "https://oauth2.googleapis.com/token",
             data={
                 "refresh_token": refresh_token,
-                "client_id": self.google_client_id,
-                "client_secret": self.google_client_secret,
+                "client_id": google_client_id,
+                "client_secret": google_client_secret,
                 "grant_type": "refresh_token",
             },
             timeout=10,
@@ -102,15 +107,16 @@ class AuthService:
         return response.json()
 
     async def exchange_github_code(self, code: str) -> Dict[str, Any]:
-        if not self.github_client_id or not self.github_client_secret:
+        github_client_id, github_client_secret = await self._github_creds()
+        if not github_client_id or not github_client_secret:
             raise ValueError("GitHub OAuth is not configured")
 
         resp = requests.post(
             "https://github.com/login/oauth/access_token",
             headers={"Accept": "application/json"},
             data={
-                "client_id": self.github_client_id,
-                "client_secret": self.github_client_secret,
+                "client_id": github_client_id,
+                "client_secret": github_client_secret,
                 "code": code,
             },
             timeout=10,

--- a/services/oauth_credentials_service.py
+++ b/services/oauth_credentials_service.py
@@ -142,7 +142,7 @@ class OAuthCredentialsService:
 
             # Refresh
             if provider == "google":
-                new_payload = self._refresh_google(row.payload)
+                new_payload = await self._refresh_google(row.payload)
             elif provider == "github":
                 # GitHub OAuth tokens don't expire by default; treat as fine.
                 return decrypt(row.payload["access_token"])
@@ -170,10 +170,13 @@ class OAuthCredentialsService:
         return dt <= datetime.now(timezone.utc) + timedelta(seconds=60)
 
     @staticmethod
-    def _refresh_google(payload: dict[str, Any]) -> dict[str, Any] | None:
-        settings = get_settings()
-        if not settings.google_client_secret:
-            logger.error("Cannot refresh Google token: GOOGLE_CLIENT_SECRET not set")
+    async def _refresh_google(payload: dict[str, Any]) -> dict[str, Any] | None:
+        from services.secrets_service import get_secrets_service
+        client = await get_secrets_service().get_oauth_client("google")
+        client_id = client.get("client_id", "")
+        client_secret = client.get("client_secret", "")
+        if not client_secret:
+            logger.error("Cannot refresh Google token: client_secret not configured")
             return None
         rt_enc = payload.get("refresh_token")
         if not rt_enc:
@@ -188,8 +191,8 @@ class OAuthCredentialsService:
                 "https://oauth2.googleapis.com/token",
                 data={
                     "refresh_token": refresh_token,
-                    "client_id": settings.google_oauth_client_id,
-                    "client_secret": settings.google_client_secret,
+                    "client_id": client_id,
+                    "client_secret": client_secret,
                     "grant_type": "refresh_token",
                 },
                 timeout=10,

--- a/services/secrets_service.py
+++ b/services/secrets_service.py
@@ -1,0 +1,269 @@
+"""Encrypted secret storage on top of AppSetting.
+
+Layout in AppSetting (user_id="default"):
+  key="secrets.{name}"          value={"value": <encrypted>, "updated_at": ...}
+  key="oauth_clients.{provider}" value={"client_id": <enc>, "client_secret": <enc>, ...}
+  key="pyjiit.credentials"      value={"username": <enc>, "password": <enc>}
+  key="composio.config"         value={"api_key": <enc>, "user_id": <enc>}
+
+Plaintext values never leave this module — callers receive resolved values via
+`resolve()` (used internally by services) or masked values via `*_public()`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from core import get_logger
+from core.config import get_settings
+from core.crypto import CryptoNotConfigured, decrypt, encrypt
+from services.app_state import AppStateService
+
+logger = get_logger(__name__)
+
+
+# Map external "key names" → (AppSetting key, env var, settings attr).
+# settings attr lets us fall back to pydantic-resolved env value (which may
+# include defaults like google_oauth_client_id).
+SECRET_REGISTRY: dict[str, tuple[str, str, str | None]] = {
+    "google_api_key":      ("secrets.google_api_key",      "GOOGLE_API_KEY",      "google_api_key"),
+    "openai_api_key":      ("secrets.openai_api_key",      "OPENAI_API_KEY",      "openai_api_key"),
+    "anthropic_api_key":   ("secrets.anthropic_api_key",   "ANTHROPIC_API_KEY",   "anthropic_api_key"),
+    "deepseek_api_key":    ("secrets.deepseek_api_key",    "DEEPSEEK_API_KEY",    "deepseek_api_key"),
+    "openrouter_api_key":  ("secrets.openrouter_api_key",  "OPENROUTER_API_KEY",  "openrouter_api_key"),
+    "tavily_api_key":      ("secrets.tavily_api_key",      "TAVILY_API_KEY",      "tavily_api_key"),
+    "ollama_base_url":     ("secrets.ollama_base_url",     "OLLAMA_BASE_URL",     "ollama_base_url"),
+}
+
+
+def mask(value: str | None) -> str | None:
+    if not value:
+        return None
+    if len(value) <= 8:
+        return "•" * len(value)
+    return f"{value[:3]}•••••{value[-4:]}"
+
+
+class SecretsService:
+    """Read/write encrypted secrets in AppSetting; resolve with env fallback."""
+
+    def __init__(self):
+        self._state = AppStateService()
+
+    # ── individual named secrets (LLM keys etc.) ────────────────────────────
+    async def get_raw(self, name: str) -> str | None:
+        if name not in SECRET_REGISTRY:
+            return None
+        key, _, _ = SECRET_REGISTRY[name]
+        row = await self._state.get_setting(key)
+        if not row:
+            return None
+        enc = row.get("value")
+        if not enc:
+            return None
+        try:
+            return decrypt(enc)
+        except CryptoNotConfigured:
+            logger.warning("Cannot decrypt %s: encryption key not configured", name)
+            return None
+        except Exception:
+            logger.exception("Failed to decrypt secret %s", name)
+            return None
+
+    async def set(self, name: str, value: str) -> None:
+        if name not in SECRET_REGISTRY:
+            raise ValueError(f"unknown secret: {name}")
+        key, _, _ = SECRET_REGISTRY[name]
+        await self._state.set_setting(key, {"value": encrypt(value)})
+
+    async def clear(self, name: str) -> None:
+        if name not in SECRET_REGISTRY:
+            raise ValueError(f"unknown secret: {name}")
+        key, _, _ = SECRET_REGISTRY[name]
+        await self._state.delete_setting(key)
+
+    async def resolve(self, name: str) -> str:
+        """DB override → env var → settings attr → ''. Never raises."""
+        if name not in SECRET_REGISTRY:
+            return ""
+        db_val = await self.get_raw(name)
+        if db_val:
+            return db_val
+        _, env_name, attr = SECRET_REGISTRY[name]
+        env_val = os.environ.get(env_name)
+        if env_val:
+            return env_val
+        if attr:
+            return getattr(get_settings(), attr, "") or ""
+        return ""
+
+    def resolve_sync(self, name: str) -> str:
+        """Sync resolve — falls back to env/settings only (no DB).
+        Useful in non-async hot paths; DB-stored overrides require async."""
+        if name not in SECRET_REGISTRY:
+            return ""
+        _, env_name, attr = SECRET_REGISTRY[name]
+        env_val = os.environ.get(env_name)
+        if env_val:
+            return env_val
+        if attr:
+            return getattr(get_settings(), attr, "") or ""
+        return ""
+
+    async def list_status(self) -> list[dict[str, Any]]:
+        """For UI: which secrets are set, where, and a masked preview."""
+        out: list[dict[str, Any]] = []
+        for name, (key, env_name, attr) in SECRET_REGISTRY.items():
+            row = await self._state.get_setting(key)
+            db_set = bool(row and row.get("value"))
+            db_preview: str | None = None
+            if db_set:
+                try:
+                    db_preview = mask(decrypt(row["value"]))
+                except Exception:
+                    db_preview = "•••"
+            env_val = os.environ.get(env_name) or (getattr(get_settings(), attr, "") if attr else "")
+            out.append({
+                "name": name,
+                "env_var": env_name,
+                "db_set": db_set,
+                "env_set": bool(env_val),
+                "source": "db" if db_set else ("env" if env_val else "unset"),
+                "masked": db_preview or (mask(env_val) if env_val else None),
+            })
+        return out
+
+    # ── OAuth client credentials ────────────────────────────────────────────
+    async def get_oauth_client(self, provider: str) -> dict[str, str]:
+        """Returns {client_id, client_secret, ...} with env fallback."""
+        provider = provider.lower()
+        row = await self._state.get_setting(f"oauth_clients.{provider}") or {}
+        out: dict[str, str] = {}
+        for field in ("client_id", "client_secret"):
+            enc = row.get(field)
+            if enc:
+                try:
+                    out[field] = decrypt(enc)
+                except Exception:
+                    logger.exception("decrypt oauth_clients.%s.%s failed", provider, field)
+        # env fallbacks
+        s = get_settings()
+        if provider == "google":
+            out.setdefault("client_id", s.google_oauth_client_id)
+            out.setdefault("client_secret", s.google_client_secret or os.environ.get("GOOGLE_CLIENT_SECRET", ""))
+        elif provider == "github":
+            out.setdefault("client_id", s.github_client_id or os.environ.get("GITHUB_CLIENT_ID", ""))
+            out.setdefault("client_secret", s.github_client_secret or os.environ.get("GITHUB_CLIENT_SECRET", ""))
+        return out
+
+    async def set_oauth_client(
+        self, provider: str, *, client_id: Optional[str] = None, client_secret: Optional[str] = None
+    ) -> None:
+        provider = provider.lower()
+        key = f"oauth_clients.{provider}"
+        existing = await self._state.get_setting(key) or {}
+        merged = dict(existing)
+        if client_id is not None:
+            merged["client_id"] = encrypt(client_id) if client_id else ""
+        if client_secret is not None:
+            merged["client_secret"] = encrypt(client_secret) if client_secret else ""
+        await self._state.set_setting(key, merged)
+
+    async def clear_oauth_client(self, provider: str) -> None:
+        await self._state.delete_setting(f"oauth_clients.{provider.lower()}")
+
+    async def list_oauth_clients(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for provider in ("google", "github"):
+            resolved = await self.get_oauth_client(provider)
+            row = await self._state.get_setting(f"oauth_clients.{provider}") or {}
+            out.append({
+                "provider": provider,
+                "client_id_masked": mask(resolved.get("client_id")),
+                "client_secret_masked": mask(resolved.get("client_secret")),
+                "client_id_source": "db" if row.get("client_id") else ("env" if resolved.get("client_id") else "unset"),
+                "client_secret_source": "db" if row.get("client_secret") else ("env" if resolved.get("client_secret") else "unset"),
+            })
+        return out
+
+    # ── Composio ───────────────────────────────────────────────────────────
+    async def get_composio(self) -> dict[str, str]:
+        row = await self._state.get_setting("composio.config") or {}
+        out: dict[str, str] = {}
+        for f in ("api_key", "user_id"):
+            enc = row.get(f)
+            if enc:
+                try:
+                    out[f] = decrypt(enc)
+                except Exception:
+                    logger.exception("decrypt composio.%s failed", f)
+        s = get_settings()
+        out.setdefault("api_key", s.composio_api_key)
+        out.setdefault("user_id", s.composio_user_id)
+        return out
+
+    async def set_composio(self, *, api_key: Optional[str] = None, user_id: Optional[str] = None) -> None:
+        existing = await self._state.get_setting("composio.config") or {}
+        merged = dict(existing)
+        if api_key is not None:
+            merged["api_key"] = encrypt(api_key) if api_key else ""
+        if user_id is not None:
+            merged["user_id"] = encrypt(user_id) if user_id else ""
+        await self._state.set_setting("composio.config", merged)
+
+    async def clear_composio(self) -> None:
+        await self._state.delete_setting("composio.config")
+
+    async def composio_public(self) -> dict[str, Any]:
+        resolved = await self.get_composio()
+        row = await self._state.get_setting("composio.config") or {}
+        return {
+            "api_key_masked": mask(resolved.get("api_key")),
+            "user_id": resolved.get("user_id") or None,
+            "api_key_source": "db" if row.get("api_key") else ("env" if resolved.get("api_key") else "unset"),
+            "user_id_source": "db" if row.get("user_id") else ("env" if resolved.get("user_id") else "unset"),
+        }
+
+    # ── PyJIIT ─────────────────────────────────────────────────────────────
+    async def get_pyjiit(self) -> dict[str, str]:
+        row = await self._state.get_setting("pyjiit.credentials") or {}
+        out: dict[str, str] = {}
+        for f in ("username", "password"):
+            enc = row.get(f)
+            if enc:
+                try:
+                    out[f] = decrypt(enc)
+                except Exception:
+                    logger.exception("decrypt pyjiit.%s failed", f)
+        return out
+
+    async def set_pyjiit(self, *, username: Optional[str] = None, password: Optional[str] = None) -> None:
+        existing = await self._state.get_setting("pyjiit.credentials") or {}
+        merged = dict(existing)
+        if username is not None:
+            merged["username"] = encrypt(username) if username else ""
+        if password is not None:
+            merged["password"] = encrypt(password) if password else ""
+        await self._state.set_setting("pyjiit.credentials", merged)
+
+    async def clear_pyjiit(self) -> None:
+        await self._state.delete_setting("pyjiit.credentials")
+
+    async def pyjiit_public(self) -> dict[str, Any]:
+        creds = await self.get_pyjiit()
+        return {
+            "username": creds.get("username") or None,
+            "password_masked": mask(creds.get("password")),
+            "configured": bool(creds.get("username") and creds.get("password")),
+        }
+
+
+_singleton: SecretsService | None = None
+
+
+def get_secrets_service() -> SecretsService:
+    global _singleton
+    if _singleton is None:
+        _singleton = SecretsService()
+    return _singleton


### PR DESCRIPTION
## Summary
- add encrypted secret storage plus editable integrations settings for OAuth clients, LLM providers, Composio, and PyJIIT
- wire the backend and debug dashboard to use stored credentials, richer OAuth flows, and reloadable default LLM configuration
- refresh the debug and extension UIs with richer markdown rendering, improved run inspection, dashboard polish, and the latest `inpo-boop-agent` submodule update

## Verification
- `pnpm build` in `debug`
- `python -m compileall main.py core routers services`